### PR TITLE
Add agent guidance and optimize idle streaming work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md
+
+## Core Priorities
+
+1. Keep streaming latency low and frame delivery bounded.
+2. Preserve reliability across reconnects, partial streams and decoder fallback.
+3. Keep controller, touch and keyboard input predictable.
+
+Choose correctness and recovery over a local shortcut. Performance changes must
+retain bounded queues and must not weaken the existing resynchronization paths.
+
+## Repository Layout
+
+- `app/src/` contains the launcher, GeForce NOW API client and streaming runtime.
+- `app/src/stream/` owns audio, video decoding and rendering. Deko3D is the
+  Switch path; OpenGL is the host/reference path.
+- `resources/` contains RomFS fonts, translations, icons and UI assets.
+- `tests/` contains small host-side policy and parsing tests.
+- `scripts/` and `build-switch.ps1` contain the supported build and packaging
+  entry points.
+- `extern/` is vendored third-party code. Do not edit it unless a task
+  explicitly requires an upstream dependency patch.
+
+## Module Boundaries
+
+- Keep NVIDIA/GFN HTTP, authentication, account persistence and catalog parsing
+  in `gfn_client.*`; UI views should consume its typed models instead of
+  rebuilding requests.
+- Keep signaling and peer-connection state in `webrtc_session.*`. WebSocket
+  framing belongs in `WebSocketClient.*` and the `SignalingClient` wrapper.
+- Keep stream-setting defaults and persistence in `stream_settings.*`; put
+  independently testable selection rules in focused `*_policy.hpp` headers.
+- Keep platform-specific rendering behind `IVideoRenderer`. Do not introduce
+  Deko3D details into UI code or assume OpenGL exists on Switch.
+- Preserve the public data-channel report formats and the Xbox-compatible input
+  contract when changing controller code.
+
+## Streaming and Concurrency
+
+- The network worker owns `peer_connection_loop`; the decoder worker owns decode
+  submission; the UI thread polls signaling and renders completed frames.
+- Keep `decoder_queue_` bounded. On congestion, dropping stale work and
+  requesting a keyframe is preferable to growing latency.
+- Do not hold `peer_mutex_` while performing unrelated file or UI work. Maintain
+  the established lock ordering when touching peer, decoder queue or logging
+  state.
+- Avoid busy polling. If a worker has no work, use the existing backoff policy
+  or a condition variable while keeping wake-up latency explicit.
+- Diagnostic logging is opt-in. Do not add per-packet or per-frame logging to
+  the normal gameplay path.
+
+## Persistence and Security
+
+- Runtime data belongs under the paths provided by `app_paths.*`; do not add
+  repository-local account, token or log files.
+- Keep account, settings and credential writes atomic and preserve backup
+  recovery behavior.
+- Never log bearer tokens, passwords, session cookies or decrypted credentials.
+- TLS verification, authentication headers and persisted-data compatibility are
+  security boundaries, not refactoring conveniences.
+
+## Maintainability
+
+- Prefer a small typed helper beside its owning subsystem over a broad utility
+  module.
+- Reuse existing policy headers for behavior that can be tested without Switch
+  hardware.
+- Match the existing C++20 style and keep public interfaces stable unless the
+  task requires a contract change.
+- Do not mix inherited SwitchNOW-to-OpenNOW renaming with unrelated behavior
+  changes; paths, package names and persisted data require an explicit migration.
+
+## Checks
+
+- Run the narrowest relevant host test first. A header-only test can be compiled
+  with `g++ -std=c++20 -Wall -Wextra -Werror -Iapp/src tests/<name>.cpp`.
+- When a test exercises a `.cpp` implementation, compile that implementation
+  into the same host test and link its host dependency, such as Jansson.
+- For Switch-facing changes, run `./scripts/build-switch-msys2.sh` in a devkitPro
+  MSYS2 environment, or `./build-switch.ps1` from PowerShell.
+- Do not claim the Switch build passed from a host-only compile. If the devkitPro
+  toolchain is unavailable, report that limitation and still run all applicable
+  host tests.
+
+## Development Environment
+
+- The production target is Nintendo Switch homebrew using devkitA64, libnx,
+  Deko3D, Borealis and the pinned libraries under `extern/`.
+- The unified `SwitchNOW.nro` build contains NVDEC and software-decoder fallback;
+  do not use the legacy NVDEC script as a separate build flavor.
+- CMake requires `DEVKITPRO` and configures `Switch.cmake` before the project.
+  Standard desktop CMake configuration is therefore not a valid build check.
+- Full login and gameplay tests require a real NVIDIA/GeForce NOW account and
+  Switch hardware. Never add credentials or captured sessions to tests.

--- a/app/src/network_loop_policy.hpp
+++ b/app/src/network_loop_policy.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace opennow::network
+{
+
+constexpr int LoopBackoffMilliseconds(bool ready, int processed_datagrams)
+{
+    if (processed_datagrams > 0)
+        return 0;
+    return ready ? 1 : 2;
+}
+
+} // namespace opennow::network

--- a/app/src/stream/OpenGL/GLVideoRenderer.hpp
+++ b/app/src/stream/OpenGL/GLVideoRenderer.hpp
@@ -21,7 +21,7 @@ extern "C"
 
 class GLVideoRenderer : public IVideoRenderer {
   public:
-    GLVideoRenderer(){};
+    GLVideoRenderer() = default;
     ~GLVideoRenderer();
 
     void draw(NVGcontext* vg, int width, int height, AVFrame* frame, int imageFormat) override;
@@ -57,19 +57,19 @@ class GLVideoRenderer : public IVideoRenderer {
     uint64_t m_rendered_frame_count = 0;
     uint64_t m_uploaded_generation = 0;
     uint64_t m_unique_frame_count = 0;
-    int m_yuvmat_location;
-    int m_offset_location;
-    int m_uv_data_location;
-    int textureWidth[PLANES_NUM_MAX];
-    int textureHeight[PLANES_NUM_MAX];
+    int m_yuvmat_location = -1;
+    int m_offset_location = -1;
+    int m_uv_data_location = -1;
+    int textureWidth[PLANES_NUM_MAX] = {};
+    int textureHeight[PLANES_NUM_MAX] = {};
     float borderColor[PLANES_NUM_MAX] = {0.0f, 0.5f, 0.5f};
     VideoRenderStats m_video_render_stats_progress = {};
     VideoRenderStats m_video_render_stats_cache = {};
     uint64_t timeCount = 0;
 
     int currentFrameTypePlanesNum = 0;
-    const int (*currentPlanes)[5];
-    int currentFormat;
+    const int (*currentPlanes)[5] = nullptr;
+    int currentFormat = 0;
 };
 
 #endif // USE_GL_RENDERER

--- a/app/src/webrtc_session.cpp
+++ b/app/src/webrtc_session.cpp
@@ -1,4 +1,5 @@
 #include "webrtc_session.hpp"
+#include "network_loop_policy.hpp"
 #include "stream/RemoteCandidatePolicy.hpp"
 #include "borealis.hpp"
 #include "stream/audio/AudioRtpUtils.hpp"
@@ -1578,6 +1579,7 @@ void WebRtcSession::start_network_worker() {
 void WebRtcSession::network_loop() {
     while (network_running_.load(std::memory_order_acquire)) {
         bool can_run = false;
+        int batch_size = 0;
         {
             std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
             can_run = pc_ && signaling_ready_ && remote_description_set_ &&
@@ -1589,7 +1591,6 @@ void WebRtcSession::network_loop() {
                 constexpr int kMaximumDatagramsPerBatch = 24;
                 constexpr auto kMaximumBatchTime = std::chrono::microseconds(1000);
                 const auto batch_started_at = std::chrono::steady_clock::now();
-                int batch_size = 0;
                 for (int packet = 0; packet < kMaximumDatagramsPerBatch; ++packet) {
                     if (peer_connection_loop(pc_) == 0)
                         break;
@@ -1609,8 +1610,10 @@ void WebRtcSession::network_loop() {
             }
         }
 
-        if (!can_run)
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        const int backoff_ms =
+            opennow::network::LoopBackoffMilliseconds(can_run, batch_size);
+        if (backoff_ms > 0)
+            std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
         else
             std::this_thread::yield();
     }
@@ -1883,12 +1886,13 @@ void WebRtcSession::stop() {
 void WebRtcSession::handle_signaling_message(const std::string& msg) {
     signaling_rx_count_++;
     AppendStreamLog("RX " + msg);
-    AppendTraceLog(CompactSignalingMessage(msg));
+    const std::string compact_message = CompactSignalingMessage(msg);
+    AppendTraceLog(compact_message);
 
     if (last_messages_.size() >= 3) {
         last_messages_.erase(last_messages_.begin());
     }
-    last_messages_.push_back(CompactSignalingMessage(msg));
+    last_messages_.push_back(compact_message);
 
     json_error_t error;
     json_t* root = json_loads(msg.c_str(), 0, &error);

--- a/tests/network_loop_policy_test.cpp
+++ b/tests/network_loop_policy_test.cpp
@@ -1,0 +1,16 @@
+#include "network_loop_policy.hpp"
+
+#include <cassert>
+
+static_assert(opennow::network::LoopBackoffMilliseconds(false, 0) == 2);
+static_assert(opennow::network::LoopBackoffMilliseconds(true, 0) == 1);
+static_assert(opennow::network::LoopBackoffMilliseconds(true, 1) == 0);
+static_assert(opennow::network::LoopBackoffMilliseconds(true, 24) == 0);
+
+int main()
+{
+    using opennow::network::LoopBackoffMilliseconds;
+    assert(LoopBackoffMilliseconds(false, 0) > LoopBackoffMilliseconds(true, 0));
+    assert(LoopBackoffMilliseconds(true, 8) == 0);
+    return 0;
+}


### PR DESCRIPTION
Adds repository-specific agent guidance modeled on OpenNOW and tightens the streaming runtime’s idle behavior.

- Documents the Switch architecture, module boundaries, security constraints, concurrency rules, and valid verification paths in `AGENTS.md`.
- Backs off the peer network worker when no datagrams are available instead of continuously yielding, while preserving immediate batch processing when traffic arrives.
- Reuses each compact signaling summary instead of parsing the same message twice.
- Initializes OpenGL renderer state defensively and adds a focused host test for the network-loop backoff policy.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/67c245a4-ad00-4c77-a342-66a9c09ee1f5/thread/6f9bcfeb-2836-4e7a-902e-6299d6261fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-001" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/67c245a4-ad00-4c77-a342-66a9c09ee1f5/thread/6f9bcfeb-2836-4e7a-902e-6299d6261fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-001&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-001"><img alt="OPEN-001" src="https://capy.ai/api/badge/thread.svg?label=OPEN-001"></picture></a>
<!-- capy-pr-badge:end -->