### PR TITLE
Fix launcher bugs and polish the OpenNOW UI

### DIFF
--- a/app/src/WebSocketClient.cpp
+++ b/app/src/WebSocketClient.cpp
@@ -16,6 +16,9 @@
 namespace
 {
 
+constexpr size_t kMaximumHandshakeBytes = 64 * 1024;
+constexpr size_t kMaximumSignalingPayloadBytes = 4 * 1024 * 1024;
+
 std::vector<uint8_t> random_bytes(size_t length)
 {
     std::vector<uint8_t> bytes(length);
@@ -99,7 +102,7 @@ bool WebSocketClient::connect() {
     size_t path_pos = host.find("/");
     if (path_pos != std::string::npos) {
         path = host.substr(path_pos);
-        host = host.substr(0, path_pos);
+        host.resize(path_pos);
     }
     
     const std::string host_header = host;
@@ -111,7 +114,7 @@ bool WebSocketClient::connect() {
     if (colon_pos != std::string::npos) {
         std::string port_str = host.substr(colon_pos + 1);
         if (port_str == "443" || port_str == "80") {
-            host = host.substr(0, colon_pos);
+            host.resize(colon_pos);
         }
     }
 
@@ -122,8 +125,8 @@ bool WebSocketClient::connect() {
 
     curl_easy_setopt(curl_, CURLOPT_URL, curl_url.c_str());
     curl_easy_setopt(curl_, CURLOPT_CONNECT_ONLY, 1L);
-    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYHOST, 2L);
     curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT, 15L);
     curl_easy_setopt(curl_, CURLOPT_NOSIGNAL, 1L);
 
@@ -162,6 +165,10 @@ bool WebSocketClient::connect() {
         res = curl_easy_recv(curl_, buf, sizeof(buf) - 1, &rcvd);
         if (res == CURLE_OK && rcvd > 0) {
             response.append(buf, rcvd);
+            if (response.size() > kMaximumHandshakeBytes) {
+                last_error_ = "WebSocket handshake response is too large";
+                break;
+            }
             const size_t header_end = response.find("\r\n\r\n");
             if (header_end == std::string::npos)
                 continue;
@@ -319,6 +326,13 @@ void WebSocketClient::poll() {
             }
             payload_len = static_cast<size_t>(big_len);
         }
+
+        if (payload_len > kMaximumSignalingPayloadBytes ||
+            payload_len > std::numeric_limits<size_t>::max() - header_size) {
+            last_error_ = "Incoming WebSocket frame is too large";
+            connected_ = false;
+            return;
+        }
         
         if (masked) {
             header_size += 4;
@@ -334,7 +348,9 @@ void WebSocketClient::poll() {
             memcpy(mask_key, &rx_buffer_[header_size - 4], 4);
         }
         
-        std::vector<uint8_t> payload(&rx_buffer_[header_size], &rx_buffer_[header_size + payload_len]);
+        std::vector<uint8_t> payload(payload_len);
+        if (payload_len > 0)
+            std::memcpy(payload.data(), rx_buffer_.data() + header_size, payload_len);
         
         if (masked) {
             for (size_t i = 0; i < payload_len; i++) {

--- a/app/src/WebSocketClient.hpp
+++ b/app/src/WebSocketClient.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <cstdint>
 #include <curl/curl.h>
 
 class WebSocketClient {

--- a/app/src/catalog_tab.cpp
+++ b/app/src/catalog_tab.cpp
@@ -6,6 +6,7 @@
 #include "game_grid_navigation.hpp"
 #include "ui_action_guard.hpp"
 #include "ui_helpers.hpp"
+#include "ui_text_policy.hpp"
 #include "localization.hpp"
 
 #include <algorithm>
@@ -40,7 +41,7 @@ brls::Button* MakeToolbarButton(const std::string& text)
     button->setFontSize(15);
     button->setStyle(&brls::BUTTONSTYLE_BORDERED);
     button->setHeight(42);
-    button->setWidth(static_cast<float>(std::max<size_t>(170, localized.size() * 9 + 38)));
+    button->setWidth(ui::ToolbarButtonWidth(localized));
     button->setMarginRight(10);
     return button;
 }
@@ -79,7 +80,7 @@ CatalogTab::CatalogTab()
     : brls::Box(brls::Axis::COLUMN)
 {
     setPadding(18, 32, 18, 32);
-    setBackgroundColor(nvgRGB(11, 12, 15));
+    setBackgroundColor(nvgRGB(16, 16, 20));
 
     auto* heading = new brls::Box(brls::Axis::ROW);
     heading->setAlignItems(brls::AlignItems::CENTER);
@@ -88,7 +89,7 @@ CatalogTab::CatalogTab()
     accent->setWidth(4);
     accent->setHeight(30);
     accent->setMarginRight(12);
-    accent->setColor(nvgRGB(92, 238, 139));
+    accent->setColor(nvgRGB(88, 217, 138));
     heading->addView(accent);
     auto* title = MakeParagraph("Store", 0.0f);
     title->setFontSize(28);

--- a/app/src/game_card_view.cpp
+++ b/app/src/game_card_view.cpp
@@ -51,6 +51,7 @@ GameCardView::GameCardView(GameCardDisplay display, ClickHandler click_handler)
     image_ = new brls::Image();
     image_->setWidth(212);
     image_->setHeight(112);
+    image_->setCornerRadius(7);
     image_->setMarginBottom(6);
     image_->setScalingType(brls::ImageScalingType::FILL);
     addView(image_);
@@ -59,7 +60,7 @@ GameCardView::GameCardView(GameCardDisplay display, ClickHandler click_handler)
     title_label_->setMarginBottom(3);
     addView(title_label_);
 
-    subtitle_label_ = MakeLabel(BuildSubtitle(display_), 12.0f, nvgRGB(105, 220, 148));
+    subtitle_label_ = MakeLabel(BuildSubtitle(display_), 12.0f, nvgRGB(88, 217, 138));
     addView(subtitle_label_);
 
     UpdateChrome(false);
@@ -88,8 +89,8 @@ void GameCardView::onFocusLost()
 
 void GameCardView::UpdateChrome(bool focused)
 {
-    setBackgroundColor(focused ? nvgRGB(29, 33, 38) : nvgRGB(17, 19, 23));
-    setBorderColor(focused ? nvgRGB(92, 238, 139) : nvgRGB(39, 42, 48));
+    setBackgroundColor(focused ? nvgRGB(26, 42, 34) : nvgRGB(21, 21, 24));
+    setBorderColor(focused ? nvgRGB(88, 217, 138) : nvgRGB(42, 42, 48));
 }
 
 void GameCardView::LoadImage()

--- a/app/src/game_detail_policy.hpp
+++ b/app/src/game_detail_policy.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace opennow::game_detail
+{
+
+inline bool IsUnknownMetadata(const std::string& value)
+{
+    if (value.empty())
+        return true;
+
+    std::string normalized = value;
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::toupper(ch));
+    });
+    return normalized == "UNKNOWN" || normalized == "N/A" || normalized == "UNAVAILABLE";
+}
+
+inline std::string DisplayStore(const std::string& store)
+{
+    return IsUnknownMetadata(store) ? std::string("GeForce NOW") : store;
+}
+
+inline std::string DetailSubtitle(bool owned)
+{
+    return owned ? "In your GeForce NOW library" : "Available on GeForce NOW";
+}
+
+inline std::string HeaderSubtitle(bool owned)
+{
+    return owned ? "GeForce NOW library" : "GeForce NOW catalog";
+}
+
+inline std::string FormatLastPlayed(const std::string& value)
+{
+    if (value.empty())
+        return "Never";
+
+    if (value.size() >= 16 && value[4] == '-' && value[7] == '-' && value[10] == 'T' &&
+        value[13] == ':' && value.back() == 'Z') {
+        return value.substr(0, 10) + "  ·  " + value.substr(11, 5) + " UTC";
+    }
+
+    return value;
+}
+
+} // namespace opennow::game_detail

--- a/app/src/game_detail_view.cpp
+++ b/app/src/game_detail_view.cpp
@@ -2,6 +2,7 @@
 
 #include "app_state.hpp"
 #include "cover_image_cache.hpp"
+#include "game_detail_policy.hpp"
 #include "nte_credentials.hpp"
 #include "ui_helpers.hpp"
 #include "localization.hpp"
@@ -33,9 +34,9 @@ brls::Label* MakeLabel(const std::string& text, float size, NVGcolor color, floa
 std::string PrimaryStore(const GameInfo& game)
 {
     if (!game.available_stores.empty())
-        return game.available_stores.front();
+        return game_detail::DisplayStore(game.available_stores.front());
 
-    if (!game.publisher.empty())
+    if (!game_detail::IsUnknownMetadata(game.publisher))
         return game.publisher;
 
     return "GeForce NOW";
@@ -51,7 +52,7 @@ std::string JoinStores(const GameInfo& game)
     {
         if (i > 0)
             stream << ", ";
-        stream << game.available_stores[i];
+        stream << game_detail::DisplayStore(game.available_stores[i]);
     }
     return stream.str();
 }
@@ -131,6 +132,7 @@ GameDetailView::GameDetailView(const GfnClient& client, GameDetailData data)
     }
 
     setPadding(28, 40, 28, 40);
+    setBackgroundColor(nvgRGB(16, 16, 20));
 
     auto* header = new brls::Header();
     header->setTitle(data_.title);
@@ -142,13 +144,13 @@ GameDetailView::GameDetailView(const GfnClient& client, GameDetailData data)
     content->setMarginTop(16);
 
     auto* poster_column = new brls::Box(brls::Axis::COLUMN);
-    poster_column->setWidth(350);
-    poster_column->setMarginRight(32);
+    poster_column->setWidth(330);
+    poster_column->setMarginRight(28);
 
     auto* poster = new brls::Image();
-    poster->setWidth(330);
-    poster->setHeight(470);
-    poster->setCornerRadius(12);
+    poster->setWidth(310);
+    poster->setHeight(420);
+    poster->setCornerRadius(14);
     poster->setScalingType(brls::ImageScalingType::FILL);
     poster->setMarginBottom(16);
     SetCachedCoverImage(poster, data_.image_url);
@@ -157,6 +159,8 @@ GameDetailView::GameDetailView(const GfnClient& client, GameDetailData data)
     auto* play_button = new brls::Button();
     play_button->setStyle(&brls::BUTTONSTYLE_PRIMARY);
     play_button->setText(Tr(data_.owned ? "Play on GeForce NOW" : "Play from Store"));
+    play_button->setHeight(52);
+    play_button->setCornerRadius(10);
     play_button->registerClickAction([this](brls::View* view) {
         (void)view;
         Play();
@@ -166,6 +170,8 @@ GameDetailView::GameDetailView(const GfnClient& client, GameDetailData data)
 
     store_button_ = new brls::Button();
     store_button_->setMarginTop(10);
+    store_button_->setHeight(46);
+    store_button_->setCornerRadius(10);
     store_button_->registerClickAction([this](brls::View*) {
         ShowStoreSelector(false);
         return true;
@@ -178,19 +184,35 @@ GameDetailView::GameDetailView(const GfnClient& client, GameDetailData data)
     auto* info_column = new brls::Box(brls::Axis::COLUMN);
     info_column->setGrow(1.0f);
 
-    info_column->addView(MakeLabel(data_.title, 34.0f, nvgRGB(245, 246, 248), 8.0f));
-    info_column->addView(MakeLabel(Tr(data_.owned ? "In your library" : "Supported in GeForce NOW"), 20.0f, nvgRGB(88, 230, 146), 22.0f));
-    info_column->addView(MakeLabel("Stores: " + SafeText(data_.stores, "Unknown"), 19.0f, nvgRGB(210, 214, 220)));
+    info_column->addView(MakeLabel(data_.title, 32.0f, nvgRGB(236, 236, 239), 6.0f));
+    info_column->addView(MakeLabel(
+        game_detail::DetailSubtitle(data_.owned), 17.0f, nvgRGB(88, 217, 138), 18.0f));
+
+    auto* metadata = new brls::Box(brls::Axis::COLUMN);
+    metadata->setPadding(16, 18, 14, 18);
+    metadata->setMarginBottom(18);
+    metadata->setCornerRadius(12);
+    metadata->setBorderThickness(1);
+    metadata->setBorderColor(nvgRGB(42, 42, 48));
+    metadata->setBackgroundColor(nvgRGB(21, 21, 24));
+    metadata->addView(MakeLabel("GAME DETAILS", 12.0f, nvgRGB(112, 119, 130), 10.0f));
+    metadata->addView(MakeLabel(
+        "Store  ·  " + game_detail::DisplayStore(data_.stores),
+        17.0f, nvgRGB(220, 220, 225), 6.0f));
     if (!data_.membership_tier_label.empty())
     {
-        info_column->addView(MakeLabel(
-            "Membership: " + data_.membership_tier_label,
-            19.0f,
-            nvgRGB(246, 196, 80)));
+        metadata->addView(MakeLabel(
+            "Membership  ·  " + data_.membership_tier_label,
+            17.0f, nvgRGB(246, 196, 80), 6.0f));
     }
-    info_column->addView(MakeLabel("Publisher: " + SafeText(data_.publisher, "Unknown"), 19.0f, nvgRGB(210, 214, 220)));
-    info_column->addView(MakeLabel("Last played: " + SafeText(data_.last_played, "Never"), 19.0f, nvgRGB(210, 214, 220)));
-    info_column->addView(MakeLabel("Launch App ID: " + SafeText(data_.launch_app_id, "Unavailable"), 17.0f, nvgRGB(140, 148, 158), 24.0f));
+    if (!game_detail::IsUnknownMetadata(data_.publisher))
+        metadata->addView(MakeLabel(
+            "Publisher  ·  " + data_.publisher,
+            17.0f, nvgRGB(220, 220, 225), 6.0f));
+    metadata->addView(MakeLabel(
+        "Last played  ·  " + game_detail::FormatLastPlayed(data_.last_played),
+        17.0f, nvgRGB(220, 220, 225), 0.0f));
+    info_column->addView(metadata);
 
     if (IsNevernessToEverness(data_.title))
     {
@@ -204,10 +226,11 @@ GameDetailView::GameDetailView(const GfnClient& client, GameDetailData data)
         info_column->addView(nte_button_);
     }
 
+    info_column->addView(MakeLabel("ABOUT", 12.0f, nvgRGB(112, 119, 130), 8.0f));
     auto* description = MakeLabel(
         SafeText(data_.description, "No description is available yet for this title."),
-        20.0f,
-        nvgRGB(232, 235, 240),
+        18.0f,
+        nvgRGB(206, 206, 214),
         0.0f);
     description->setSingleLine(false);
 
@@ -255,8 +278,8 @@ void GameDetailView::UpdateStoreButton()
     if (!store_button_)
         return;
     const std::string store = selected_variant_index_ < data_.variants.size()
-        ? SafeText(data_.variants[selected_variant_index_].store, "Unknown")
-        : SafeText(data_.stores, "Unknown");
+        ? game_detail::DisplayStore(data_.variants[selected_variant_index_].store)
+        : game_detail::DisplayStore(data_.stores);
     store_button_->setText(Tr("Store") + ": " + store + (data_.variants.size() > 1 ? " (" + Tr("change") + ")" : ""));
 }
 
@@ -383,7 +406,7 @@ GameDetailData MakeLibraryGameDetail(const GameInfo& game)
     GameDetailData data;
     data.title         = game.title;
     data.game_id       = game.uuid.empty() ? game.id : game.uuid;
-    data.subtitle      = PrimaryStore(game) + " library title";
+    data.subtitle      = game_detail::HeaderSubtitle(true);
     data.image_url     = game.image_url;
     data.launch_app_id = game.launch_app_id;
     data.publisher     = game.publisher;
@@ -406,7 +429,7 @@ GameDetailData MakeCatalogGameDetail(const PublicGame& game)
     GameDetailData data;
     data.title         = game.title;
     data.game_id       = game.uuid.empty() ? game.id : game.uuid;
-    data.subtitle      = game.store + (game.is_in_library ? " library title" : " catalog title");
+    data.subtitle      = game_detail::HeaderSubtitle(game.is_in_library);
     data.image_url     = game.image_url;
     data.launch_app_id = game.launch_app_id.empty() ? game.id : game.launch_app_id;
     data.publisher     = game.publisher;

--- a/app/src/library_tab.cpp
+++ b/app/src/library_tab.cpp
@@ -8,6 +8,7 @@
 #include "membership_label.hpp"
 #include "ui_action_guard.hpp"
 #include "ui_helpers.hpp"
+#include "ui_text_policy.hpp"
 #include "qr_login_dialog.hpp"
 #include "localization.hpp"
 
@@ -45,7 +46,7 @@ brls::Button* MakeToolbarButton(const std::string& text)
     button->setFontSize(15);
     button->setStyle(&brls::BUTTONSTYLE_BORDERED);
     button->setHeight(42);
-    button->setWidth(static_cast<float>(std::max<size_t>(170, localized.size() * 9 + 38)));
+    button->setWidth(ui::ToolbarButtonWidth(localized));
     button->setMarginRight(10);
     return button;
 }
@@ -101,7 +102,7 @@ LibraryTab::LibraryTab()
     : brls::Box(brls::Axis::COLUMN)
 {
     setPadding(18, 32, 18, 32);
-    setBackgroundColor(nvgRGB(11, 12, 15));
+    setBackgroundColor(nvgRGB(16, 16, 20));
 
     auto* heading = new brls::Box(brls::Axis::ROW);
     heading->setAlignItems(brls::AlignItems::CENTER);
@@ -110,7 +111,7 @@ LibraryTab::LibraryTab()
     accent->setWidth(4);
     accent->setHeight(30);
     accent->setMarginRight(12);
-    accent->setColor(nvgRGB(92, 238, 139));
+    accent->setColor(nvgRGB(88, 217, 138));
     heading->addView(accent);
     auto* title = MakeParagraph("My Library", 0.0f);
     title->setFontSize(28);

--- a/app/src/stream/ffmpeg/FFmpegVideoDecoder.cpp
+++ b/app/src/stream/ffmpeg/FFmpegVideoDecoder.cpp
@@ -3,6 +3,8 @@
 #include "borealis.hpp"
 #include "../../stream_settings.hpp"
 #include "../../video_quality_policy.hpp"
+#include <cstdio>
+#include <vector>
 #ifdef PLATFORM_APPLE
 extern "C" {
 #include <libavcodec/videotoolbox.h>
@@ -45,14 +47,18 @@ FFmpegVideoDecoder::FFmpegVideoDecoder() {
 FFmpegVideoDecoder::~FFmpegVideoDecoder() = default;
 
 void ffmpegLog(void* ptr, int level, const char* fmt, va_list vargs) {
-    std::string message;
+    (void)ptr;
+    (void)level;
     va_list ap_copy;
     va_copy(ap_copy, vargs);
-    size_t len = vsnprintf(nullptr, 0, fmt, ap_copy);
-    message.resize(len + 1);  // need space for NUL
-    vsnprintf(&message[0], len + 1,fmt, vargs);
-    message.resize(len);  // remove the NUL
-    brls::Logger::debug("FFmpeg [LOG]: {}", message.c_str());
+    const int length = std::vsnprintf(nullptr, 0, fmt, ap_copy);
+    va_end(ap_copy);
+    if (length <= 0)
+        return;
+
+    std::vector<char> buffer(static_cast<size_t>(length) + 1);
+    std::vsnprintf(buffer.data(), buffer.size(), fmt, vargs);
+    brls::Logger::debug("FFmpeg [LOG]: {}", buffer.data());
 }
 
 int FFmpegVideoDecoder::setup(int video_format, int width, int height,

--- a/app/src/top_bar_frame.cpp
+++ b/app/src/top_bar_frame.cpp
@@ -4,6 +4,7 @@
 #include "cover_image_cache.hpp"
 #include "stream_settings.hpp"
 #include "localization.hpp"
+#include "ui_refresh_policy.hpp"
 #include <borealis/core/application.hpp>
 #include <borealis/core/theme.hpp>
 #include <borealis/core/logger.hpp>
@@ -14,7 +15,7 @@ TopBarFrame::TopBarFrame()
     : brls::Box(brls::Axis::COLUMN)
 {
     setGrow(1.0f);
-    setBackgroundColor(nvgRGB(11, 12, 15));
+    setBackgroundColor(nvgRGB(16, 16, 20));
 
     // Header container
     header_container_ = new brls::Box(brls::Axis::ROW);
@@ -22,15 +23,23 @@ TopBarFrame::TopBarFrame()
     header_container_->setAlignItems(brls::AlignItems::CENTER);
     header_container_->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
     header_container_->setPadding(0, 28, 0, 28);
-    header_container_->setBackgroundColor(nvgRGB(14, 15, 19));
+    header_container_->setBackgroundColor(nvgRGB(19, 19, 22));
     
     addView(header_container_);
 
-    auto* brand = new brls::Label();
-    brand->setText("SwitchNOW");
-    brand->setFontSize(24);
-    brand->setTextColor(nvgRGB(96, 236, 136));
+    auto* brand = new brls::Box(brls::Axis::COLUMN);
     brand->setWidth(210);
+    brand->setJustifyContent(brls::JustifyContent::CENTER);
+    auto* brand_name = new brls::Label();
+    brand_name->setText("OpenNOW");
+    brand_name->setFontSize(24);
+    brand_name->setTextColor(nvgRGB(88, 217, 138));
+    brand->addView(brand_name);
+    auto* brand_platform = new brls::Label();
+    brand_platform->setText("NINTENDO SWITCH");
+    brand_platform->setFontSize(10);
+    brand_platform->setTextColor(nvgRGB(112, 119, 130));
+    brand->addView(brand_platform);
     header_container_->addView(brand);
 
     tabs_container_ = new brls::Box(brls::Axis::ROW);
@@ -55,18 +64,28 @@ TopBarFrame::TopBarFrame()
     avatar_image_->setVisibility(brls::Visibility::GONE);
     account_container_->addView(avatar_image_);
 
-    status_label_ = new brls::Label();
-    status_label_->setText("Offline");
-    status_label_->setFontSize(16);
-    status_label_->setHorizontalAlign(brls::HorizontalAlign::RIGHT);
-    status_label_->setTextColor(nvgRGB(170, 178, 190));
-    status_label_->setWidth(255);
-    account_container_->addView(status_label_);
+    auto* account_labels = new brls::Box(brls::Axis::COLUMN);
+    account_labels->setWidth(255);
+    account_labels->setJustifyContent(brls::JustifyContent::CENTER);
+    account_name_label_ = new brls::Label();
+    account_name_label_->setText("Guest");
+    account_name_label_->setFontSize(15);
+    account_name_label_->setSingleLine(true);
+    account_name_label_->setHorizontalAlign(brls::HorizontalAlign::RIGHT);
+    account_name_label_->setTextColor(nvgRGB(236, 236, 239));
+    account_labels->addView(account_name_label_);
+    account_detail_label_ = new brls::Label();
+    account_detail_label_->setText("No account");
+    account_detail_label_->setFontSize(12);
+    account_detail_label_->setHorizontalAlign(brls::HorizontalAlign::RIGHT);
+    account_detail_label_->setTextColor(nvgRGB(112, 119, 130));
+    account_labels->addView(account_detail_label_);
+    account_container_->addView(account_labels);
 
     // Divider
     auto* divider = new brls::Rectangle();
     divider->setHeight(1);
-    divider->setColor(nvgRGB(35, 38, 44));
+    divider->setColor(nvgRGB(42, 42, 48));
     addView(divider);
 
     // Content container
@@ -194,7 +213,7 @@ void TopBarFrame::SelectTab(int index)
     if (active_tab_index_ == index && active_content_ != nullptr) return;
 
     active_tab_index_ = index;
-    UpdateStatusBar();
+    UpdateStatusBar(true);
 
     for (size_t i = 0; i < tabs_.size(); ++i) {
         if ((int)i == index) {
@@ -227,20 +246,30 @@ void TopBarFrame::SelectTab(int index)
     }
 }
 
-void TopBarFrame::UpdateStatusBar()
+void TopBarFrame::UpdateStatusBar(bool force)
 {
-    if (!status_label_)
+    if (!account_name_label_ || !account_detail_label_)
         return;
+
+    const auto now = std::chrono::steady_clock::now();
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now - last_status_update_);
+    if (!force && !ui::ShouldRefreshStatus(elapsed, !displayed_status_.empty()))
+        return;
+    last_status_update_ = now;
 
     const auto& state = AppState::Instance();
     const StreamSettings settings = LoadStreamSettings();
     if (!state.HasSession())
     {
         avatar_image_->setVisibility(brls::Visibility::GONE);
-        const std::string status = Tr("No account") + " | " + Tr(settings.label);
+        const std::string name = Tr("Guest");
+        const std::string detail = Tr("No account") + "  ·  " + Tr(settings.label);
+        const std::string status = name + "\n" + detail;
         if (status != displayed_status_)
         {
-            status_label_->setText(status);
+            account_name_label_->setText(name);
+            account_detail_label_->setText(detail);
             displayed_status_ = status;
         }
         return;
@@ -248,10 +277,14 @@ void TopBarFrame::UpdateStatusBar()
 
     const AuthSession& session = *state.session();
     const std::string tier = session.user.membership_tier.empty() ? std::string("FREE") : session.user.membership_tier;
-    const std::string status = session.user.display_name + " | " + tier + " | " + settings.label;
+    const std::string name =
+        session.user.display_name.empty() ? Tr("GeForce NOW account") : session.user.display_name;
+    const std::string detail = tier + "  ·  " + Tr(settings.label);
+    const std::string status = name + "\n" + detail;
     if (status != displayed_status_)
     {
-        status_label_->setText(status);
+        account_name_label_->setText(name);
+        account_detail_label_->setText(detail);
         displayed_status_ = status;
     }
 

--- a/app/src/top_bar_frame.hpp
+++ b/app/src/top_bar_frame.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <borealis.hpp>
+#include <chrono>
 #include <functional>
 #include <string>
 #include <vector>
@@ -25,16 +26,18 @@ class TopBarFrame : public brls::Box
     
   private:
     void SelectTab(int index);
-    void UpdateStatusBar();
+    void UpdateStatusBar(bool force = false);
 
     brls::Box* header_container_;
     brls::Box* tabs_container_;
     brls::Box* content_container_;
     brls::Box* account_container_;
     brls::Image* avatar_image_;
-    brls::Label* status_label_;
+    brls::Label* account_name_label_;
+    brls::Label* account_detail_label_;
     std::string displayed_avatar_url_;
     std::string displayed_status_;
+    std::chrono::steady_clock::time_point last_status_update_ {};
 
     struct TabInfo {
         std::string label;

--- a/app/src/ui_refresh_policy.hpp
+++ b/app/src/ui_refresh_policy.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <chrono>
+
+namespace opennow::ui
+{
+
+constexpr bool ShouldRefreshStatus(
+    std::chrono::milliseconds elapsed, bool has_displayed_status)
+{
+    return !has_displayed_status || elapsed >= std::chrono::seconds(1);
+}
+
+} // namespace opennow::ui

--- a/app/src/ui_text_policy.hpp
+++ b/app/src/ui_text_policy.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+namespace opennow::ui
+{
+
+inline size_t Utf8CodePointCount(const std::string& text)
+{
+    return static_cast<size_t>(std::count_if(text.begin(), text.end(), [](unsigned char ch) {
+        return (ch & 0xc0) != 0x80;
+    }));
+}
+
+inline float ToolbarButtonWidth(const std::string& text)
+{
+    const size_t estimated = Utf8CodePointCount(text) * 9 + 38;
+    return static_cast<float>(std::clamp<size_t>(estimated, 170, 250));
+}
+
+} // namespace opennow::ui

--- a/tests/game_detail_policy_test.cpp
+++ b/tests/game_detail_policy_test.cpp
@@ -1,0 +1,24 @@
+#include "game_detail_policy.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using namespace opennow::game_detail;
+
+    assert(IsUnknownMetadata(""));
+    assert(IsUnknownMetadata("UNKNOWN"));
+    assert(IsUnknownMetadata("n/a"));
+    assert(!IsUnknownMetadata("Steam"));
+    assert(DisplayStore("UNKNOWN") == "GeForce NOW");
+    assert(DisplayStore("Epic") == "Epic");
+    assert(DetailSubtitle(true) == "In your GeForce NOW library");
+    assert(DetailSubtitle(false) == "Available on GeForce NOW");
+    assert(HeaderSubtitle(true) == "GeForce NOW library");
+    assert(HeaderSubtitle(false) == "GeForce NOW catalog");
+    assert(FormatLastPlayed("") == "Never");
+    assert(FormatLastPlayed("2026-07-20T22:35:02Z") == "2026-07-20  ·  22:35 UTC");
+    assert(FormatLastPlayed("2026-07-20T22:35:02+02:00") == "2026-07-20T22:35:02+02:00");
+    assert(FormatLastPlayed("Recently") == "Recently");
+    return 0;
+}

--- a/tests/ui_refresh_policy_test.cpp
+++ b/tests/ui_refresh_policy_test.cpp
@@ -1,0 +1,16 @@
+#include "ui_refresh_policy.hpp"
+
+#include <cassert>
+#include <chrono>
+
+static_assert(opennow::ui::ShouldRefreshStatus(std::chrono::milliseconds(0), false));
+static_assert(!opennow::ui::ShouldRefreshStatus(std::chrono::milliseconds(999), true));
+static_assert(opennow::ui::ShouldRefreshStatus(std::chrono::milliseconds(1000), true));
+
+int main()
+{
+    using namespace std::chrono_literals;
+    assert(!opennow::ui::ShouldRefreshStatus(100ms, true));
+    assert(opennow::ui::ShouldRefreshStatus(1s, true));
+    return 0;
+}

--- a/tests/ui_text_policy_test.cpp
+++ b/tests/ui_text_policy_test.cpp
@@ -1,0 +1,15 @@
+#include "ui_text_policy.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using namespace opennow::ui;
+
+    assert(Utf8CodePointCount("Search") == 6);
+    assert(Utf8CodePointCount("搜索") == 2);
+    assert(ToolbarButtonWidth("Search") == 170.0f);
+    assert(ToolbarButtonWidth("This label is intentionally much too long for a toolbar") == 250.0f);
+    assert(ToolbarButtonWidth("搜索") == 170.0f);
+    return 0;
+}


### PR DESCRIPTION
Polishes the Switch launcher around OpenNOW’s visual hierarchy while fixing several bugs found during the UI and streaming audit.

- Refreshes the top bar, catalog, library cards, and game-details layout with consistent OpenNOW colors, clearer account hierarchy, rounded artwork, cleaner metadata, and user-facing fallbacks instead of raw `UNKNOWN` values or timestamps.
- Sizes localized toolbar buttons by UTF-8 characters with a safe width cap, preventing translated labels from overflowing the 1280px layout.
- Throttles status-bar settings reads from every rendered frame to once per second, while forced tab changes still refresh immediately.
- Restores TLS certificate and hostname verification for signaling, bounds handshake/frame sizes, and guards frame-length arithmetic.
- Correctly closes copied FFmpeg variadic arguments and handles formatting failures without oversized allocations.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/67c245a4-ad00-4c77-a342-66a9c09ee1f5/thread/6f9bcfeb-2836-4e7a-902e-6299d6261fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-001" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/67c245a4-ad00-4c77-a342-66a9c09ee1f5/thread/6f9bcfeb-2836-4e7a-902e-6299d6261fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-001&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-001"><img alt="OPEN-001" src="https://capy.ai/api/badge/thread.svg?label=OPEN-001"></picture></a>
<!-- capy-pr-badge:end -->