### PR TITLE
Fix login session refresh and membership status UI

### DIFF
--- a/app/src/StreamView.cpp
+++ b/app/src/StreamView.cpp
@@ -146,7 +146,8 @@ StreamView::StreamView(
     debug_diagnostics_ = stream_settings.debug_diagnostics;
     controller_layout_ = stream_settings.controller_layout;
     opennow::SetStreamDiagnosticsEnabled(debug_diagnostics_);
-    free_tier_session_ = IsFreeTier(auth_.user.membership_tier);
+    free_tier_session_ = auth_.user.membership_tier_verified &&
+        IsFreeTier(auth_.user.membership_tier);
     stream_started_at_ = std::chrono::steady_clock::now();
     is_nte_session_ = opennow::IsNevernessToEverness(game_title_);
     if (is_nte_session_) {

--- a/app/src/device_identity_policy.hpp
+++ b/app/src/device_identity_policy.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string_view>
+
+namespace opennow::device_identity
+{
+
+constexpr std::string_view kLegacyPlaceholderId =
+    "12345678-1234-5678-1234-567812345678";
+
+constexpr bool IsUsableStoredDeviceId(std::string_view value)
+{
+    return !value.empty() && value != kLegacyPlaceholderId;
+}
+
+} // namespace opennow::device_identity

--- a/app/src/gfn/authentication.cpp
+++ b/app/src/gfn/authentication.cpp
@@ -50,13 +50,17 @@ constexpr const char* kTokenEndpoint       = "https://login.nvidia.com/token";
 constexpr const char* kClientTokenEndpoint = "https://login.nvidia.com/client_token";
 constexpr const char* kUserInfoEndpoint    = "https://login.nvidia.com/userinfo";
 constexpr const char* kAuthorizeEndpoint   = "https://login.nvidia.com/authorize";
+constexpr const char* kSubscriptionEndpoint = "https://mes.geforcenow.com/v4/subscriptions";
 constexpr const char* kClientId            = "ZU7sPN-miLujMD95LfOQ453IB0AtjM8sMyvgJ9wCXEQ";
+constexpr const char* kLcarsClientId       = "ec7e38d4-03af-4b58-b131-cfb0495903ab";
+constexpr const char* kGfnClientVersion    = "2.0.80.173";
 constexpr const char* kScopes              = "openid consent email tk_client age";
 constexpr const char* kRedirectUri         = "http://localhost:2259";
 constexpr int kLoginCallbackPort           = 2259;
 constexpr const char* kNvidiaFileOrigin    = "https://nvfile";
 constexpr const char* kNvidiaFileReferer   = "https://nvfile/";
 constexpr std::int64_t kRefreshWindowMs    = 10LL * 60LL * 1000LL;
+constexpr std::int64_t kMembershipRefreshIntervalMs = 60LL * 60LL * 1000LL;
 constexpr auto kQrLoginTimeout             = std::chrono::minutes(5);
 std::mutex g_reauthentication_mutex;
 
@@ -780,7 +784,7 @@ AuthTokens ExchangeAuthorizationCode(
 AuthTokens RefreshTokens(const HttpClient& http_client, const AuthSession& session)
 {
     if (session.tokens.refresh_token.empty())
-        throw std::runtime_error("Saved GeForce NOW session cannot be refreshed");
+        throw ReauthenticationRequired("Saved GeForce NOW session cannot be refreshed. Please sign in again.");
 
     const std::string body =
         "grant_type=refresh_token"
@@ -820,6 +824,11 @@ AuthTokens RefreshTokens(const HttpClient& http_client, const AuthSession& sessi
     if (tokens.refresh_token.empty())
         tokens.refresh_token = session.tokens.refresh_token;
 
+    // NVIDIA commonly omits id_token during OAuth refresh. CloudMatch requires
+    // the signed JWT, so an omitted field must not erase the last usable token.
+    if (tokens.id_token.empty())
+        tokens.id_token = session.tokens.id_token;
+
     if (tokens.client_token.empty())
     {
         tokens.client_token              = session.tokens.client_token;
@@ -827,6 +836,68 @@ AuthTokens RefreshTokens(const HttpClient& http_client, const AuthSession& sessi
     }
 
     return tokens;
+}
+
+AuthTokens RefreshTokensWithClientToken(
+    const HttpClient& http_client, const AuthSession& session)
+{
+    if (session.tokens.client_token.empty() || session.user.user_id.empty())
+        throw std::runtime_error("Saved session has no client-token refresh mechanism");
+
+    const std::string body =
+        "grant_type=" + UrlEncode("urn:ietf:params:oauth:grant-type:client_token", true) +
+        "&client_token=" + UrlEncode(session.tokens.client_token, true) +
+        "&client_id=" + UrlEncode(kClientId, true) +
+        "&sub=" + UrlEncode(session.user.user_id, true);
+
+    const HttpResponse response = http_client.Post(
+        kTokenEndpoint,
+        GfnClient::kUserAgent,
+        BuildNvidiaAuthHeaders({}, "application/x-www-form-urlencoded; charset=UTF-8"),
+        body);
+    if (response.status_code != 200)
+    {
+        throw std::runtime_error(
+            "Client-token refresh failed with HTTP " + std::to_string(response.status_code));
+    }
+
+    JsonPtr root = LoadJson(response.body);
+    AuthTokens tokens = ParseAuthTokens(root.get());
+    if (tokens.refresh_token.empty())
+        tokens.refresh_token = session.tokens.refresh_token;
+    if (tokens.id_token.empty())
+        tokens.id_token = session.tokens.id_token;
+    if (tokens.client_token.empty())
+    {
+        tokens.client_token = session.tokens.client_token;
+        tokens.client_token_expires_at_ms = session.tokens.client_token_expires_at_ms;
+    }
+    else if (tokens.client_token != session.tokens.client_token)
+    {
+        // A rotated client token needs fresh lifetime metadata from /client_token.
+        tokens.client_token_expires_at_ms = 0;
+    }
+    return tokens;
+}
+
+AuthTokens RefreshSessionTokens(const HttpClient& http_client, const AuthSession& session)
+{
+    if (!session.tokens.client_token.empty())
+    {
+        try
+        {
+            AuthTokens refreshed = RefreshTokensWithClientToken(http_client, session);
+            AppendAuthLog("auth: client-token refresh ok");
+            return refreshed;
+        }
+        catch (const std::exception& e)
+        {
+            AppendAuthLog("auth: client-token refresh failed; trying OAuth refresh error=" +
+                          std::string(e.what()));
+        }
+    }
+
+    return RefreshTokens(http_client, session);
 }
 
 void RequestClientToken(const HttpClient& http_client, AuthTokens& tokens)
@@ -870,7 +941,8 @@ AuthUser FetchUserInfo(const HttpClient& http_client, const AuthTokens& tokens)
     user.display_name    = GetString(root.get(), "preferred_username");
     user.email           = GetString(root.get(), "email");
     user.avatar_url      = GetString(root.get(), "picture");
-    user.membership_tier = "FREE";
+    user.membership_tier.clear();
+    user.membership_tier_verified = false;
 
     if (user.display_name.empty() && !user.email.empty())
     {
@@ -886,6 +958,93 @@ AuthUser FetchUserInfo(const HttpClient& http_client, const AuthTokens& tokens)
         throw std::runtime_error("Login succeeded but user info is incomplete");
 
     return user;
+}
+
+std::vector<std::string> BuildMembershipHeaders(const std::string& token)
+{
+    return {
+        "Accept: application/json",
+        "Authorization: GFNJWT " + token,
+        "nv-client-id: " + std::string(kLcarsClientId),
+        "nv-client-type: NATIVE",
+        "nv-client-version: " + std::string(kGfnClientVersion),
+        "nv-client-streamer: NVIDIA-CLASSIC",
+        "nv-device-os: WINDOWS",
+        "nv-device-type: DESKTOP",
+        "nv-device-make: UNKNOWN",
+        "nv-device-model: UNKNOWN",
+    };
+}
+
+std::string FetchVpcId(const HttpClient& http_client, const AuthSession& session)
+{
+    const std::string token = ResolveSessionJwt(session);
+    if (token.empty())
+        return "NP-AMS-08";
+
+    const std::string url = EnsureTrailingSlash(session.provider.streaming_service_url) +
+        "v2/serverInfo";
+    std::vector<std::string> headers = BuildMembershipHeaders(token);
+    for (std::string& header : headers)
+    {
+        if (header == "nv-client-type: NATIVE")
+            header = "nv-client-type: BROWSER";
+        else if (header == "nv-client-streamer: NVIDIA-CLASSIC")
+            header = "nv-client-streamer: WEBRTC";
+    }
+
+    const HttpResponse response = http_client.Get(url, GfnClient::kUserAgent, headers);
+    if (response.status_code != 200)
+        return "NP-AMS-08";
+
+    try
+    {
+        JsonPtr root = LoadJson(response.body);
+        const std::string vpc = GetString(json_object_get(root.get(), "requestStatus"), "serverId");
+        return vpc.empty() ? "NP-AMS-08" : vpc;
+    }
+    catch (...)
+    {
+        return "NP-AMS-08";
+    }
+}
+
+bool RefreshMembershipTier(const HttpClient& http_client, AuthSession& session)
+{
+    session.membership_checked_at_ms = NowMs();
+    const std::string token = ResolveSessionJwt(session);
+    if (token.empty() || session.user.user_id.empty())
+        return false;
+
+    try
+    {
+        const std::string vpc_id = FetchVpcId(http_client, session);
+        const std::string url = std::string(kSubscriptionEndpoint) +
+            "?serviceName=gfn_pc&languageCode=en_US&vpcId=" + UrlEncode(vpc_id) +
+            "&userId=" + UrlEncode(session.user.user_id);
+        const HttpResponse response = http_client.Get(
+            url, GfnClient::kUserAgent, BuildMembershipHeaders(token));
+        if (response.status_code != 200)
+        {
+            AppendAuthLog("auth: subscription lookup failed HTTP " +
+                          std::to_string(response.status_code));
+            return false;
+        }
+
+        JsonPtr root = LoadJson(response.body);
+        const std::string tier = Trim(GetString(root.get(), "membershipTier"));
+        if (tier.empty())
+            return false;
+        session.user.membership_tier = tier;
+        session.user.membership_tier_verified = true;
+        AppendAuthLog("auth: subscription tier resolved");
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        AppendAuthLog("auth: subscription response parse failed error=" + std::string(e.what()));
+        return false;
+    }
 }
 
 
@@ -922,6 +1081,7 @@ AuthSession GfnClient::Login(const LoginProvider& provider, const std::string& l
     session.tokens   = tokens;
     session.user     = FetchUserInfo(http_client_, tokens);
     session.last_refresh_at_ms = NowMs();
+    RefreshMembershipTier(http_client_, session);
     AppendAuthLog("auth: user info ok user_id_present=" + std::string(session.user.user_id.empty() ? "no" : "yes"));
     return session;
 }
@@ -1209,6 +1369,7 @@ AuthSession GfnClient::LoginNative(
             auth_session.tokens = std::move(tokens);
             auth_session.user = FetchUserInfo(http_client_, auth_session.tokens);
             auth_session.last_refresh_at_ms = NowMs();
+            RefreshMembershipTier(http_client_, auth_session);
             AppendAuthLog("auth-native: login complete");
             return auth_session;
         }
@@ -1590,6 +1751,7 @@ AuthSession GfnClient::LoginSwitchQR(const LoginProvider& provider, std::functio
     session.tokens   = tokens;
     session.user     = FetchUserInfo(http_client_, tokens);
     session.last_refresh_at_ms = NowMs();
+    RefreshMembershipTier(http_client_, session);
     AppendAuthLog("auth: user info ok user_id_present=" + std::string(session.user.user_id.empty() ? "no" : "yes"));
     return session;
 }
@@ -1599,8 +1761,11 @@ AuthSession GfnClient::EnsureFreshSession(const AuthSession& session) const
     const bool access_needs_refresh = IsNearExpiry(session.tokens.expires_at_ms);
     const bool client_needs_refresh = session.tokens.client_token.empty() ||
         IsNearExpiry(session.tokens.client_token_expires_at_ms);
+    const bool membership_needs_refresh =
+        session.membership_checked_at_ms <= 0 ||
+        NowMs() - session.membership_checked_at_ms >= kMembershipRefreshIntervalMs;
 
-    if (!access_needs_refresh && !client_needs_refresh)
+    if (!access_needs_refresh && !client_needs_refresh && !membership_needs_refresh)
         return session;
 
     AuthSession refreshed = session;
@@ -1614,7 +1779,7 @@ AuthSession GfnClient::EnsureFreshSession(const AuthSession& session) const
     {
         AppendAuthLog("auth: refreshing access token user_id_present=" +
                       std::string(session.user.user_id.empty() ? "no" : "yes"));
-        refreshed.tokens = RefreshTokens(http_client_, session);
+        refreshed.tokens = RefreshSessionTokens(http_client_, session);
         refreshed.last_refresh_at_ms = NowMs();
         AppendAuthLog("auth: access token refresh ok");
     }
@@ -1624,6 +1789,8 @@ AuthSession GfnClient::EnsureFreshSession(const AuthSession& session) const
     {
         RequestClientToken(http_client_, refreshed.tokens);
     }
+    if (membership_needs_refresh || access_needs_refresh)
+        RefreshMembershipTier(http_client_, refreshed);
     return refreshed;
 }
 
@@ -1652,6 +1819,9 @@ AuthSession GfnClient::EnsureFreshSavedSession(const AuthSession& session) const
         refreshed.tokens.client_token != source.tokens.client_token ||
         refreshed.tokens.expires_at_ms != source.tokens.expires_at_ms ||
         refreshed.tokens.client_token_expires_at_ms != source.tokens.client_token_expires_at_ms ||
+        refreshed.user.membership_tier != source.user.membership_tier ||
+        refreshed.user.membership_tier_verified != source.user.membership_tier_verified ||
+        refreshed.membership_checked_at_ms != source.membership_checked_at_ms ||
         refreshed.last_refresh_at_ms != source.last_refresh_at_ms;
     if (changed)
         SaveSession(refreshed);
@@ -1663,13 +1833,14 @@ AuthSession GfnClient::ForceRefreshSavedSession(const AuthSession& session) cons
     if (!session.persistence_enabled)
     {
         AuthSession refreshed = session;
-        refreshed.tokens = RefreshTokens(http_client_, session);
+        refreshed.tokens = RefreshSessionTokens(http_client_, session);
         if (refreshed.tokens.client_token.empty() ||
             IsNearExpiry(refreshed.tokens.client_token_expires_at_ms))
         {
             RequestClientToken(http_client_, refreshed.tokens);
         }
         refreshed.last_refresh_at_ms = NowMs();
+        RefreshMembershipTier(http_client_, refreshed);
         return refreshed;
     }
 
@@ -1688,13 +1859,14 @@ AuthSession GfnClient::ForceRefreshSavedSession(const AuthSession& session) cons
     AppendAuthLog("auth: forced refresh after authorization failure user_id_present=" +
                   std::string(source.user.user_id.empty() ? "no" : "yes"));
     AuthSession refreshed = source;
-    refreshed.tokens = RefreshTokens(http_client_, source);
+    refreshed.tokens = RefreshSessionTokens(http_client_, source);
     if (refreshed.tokens.client_token.empty() ||
         IsNearExpiry(refreshed.tokens.client_token_expires_at_ms))
     {
         RequestClientToken(http_client_, refreshed.tokens);
     }
     refreshed.last_refresh_at_ms = NowMs();
+    RefreshMembershipTier(http_client_, refreshed);
     SaveSession(refreshed);
     return refreshed;
 }

--- a/app/src/gfn/cloud_session.cpp
+++ b/app/src/gfn/cloud_session.cpp
@@ -510,6 +510,7 @@ static std::string BuildSessionBody(
     const std::string& app_id,
     const std::string& internal_title,
     const std::string& device_id,
+    const std::string& sub_session_id,
     const StreamSettings& stream_settings)
 {
     JsonPtr root(json_object(), &json_decref);
@@ -577,7 +578,7 @@ static std::string BuildSessionBody(
     json_object_set_new(req, "requestedStreamingFeatures", features);
 
     json_t* meta = json_array();
-    json_t* m1 = json_object(); json_object_set_new(m1, "key", json_string("SubSessionId")); json_object_set_new(m1, "value", json_string(device_id.c_str())); json_array_append_new(meta, m1);
+    json_t* m1 = json_object(); json_object_set_new(m1, "key", json_string("SubSessionId")); json_object_set_new(m1, "value", json_string(sub_session_id.c_str())); json_array_append_new(meta, m1);
     json_t* m2 = json_object(); json_object_set_new(m2, "key", json_string("wssignaling")); json_object_set_new(m2, "value", json_string("1")); json_array_append_new(meta, m2);
     json_t* m3 = json_object(); json_object_set_new(m3, "key", json_string("GSStreamerType")); json_object_set_new(m3, "value", json_string("WebRTC")); json_array_append_new(meta, m3);
     json_object_set_new(req, "metaData", meta);
@@ -657,7 +658,8 @@ SessionInfo GfnClient::StartSession(AuthSession& session, const std::string& lau
 {
     session = EnsureFreshSavedSession(session);
     std::string jwt_token = ResolveSessionJwt(session);
-    const std::string device_id = device_id_;
+    const std::string device_id = GenerateDeviceId();
+    const std::string sub_session_id = GenerateUuid();
 
     const StreamSettings stream_settings = LoadStreamSettings();
     std::string url = session.provider.streaming_service_url +
@@ -671,7 +673,7 @@ SessionInfo GfnClient::StartSession(AuthSession& session, const std::string& lau
         "nv-browser-type: CHROME",
         "nv-client-streamer: NVIDIA-CLASSIC",
         "nv-client-type: NATIVE",
-        "nv-client-version: 30.0",
+        "nv-client-version: 2.0.80.173",
         "nv-device-make: UNKNOWN",
         "nv-device-model: UNKNOWN",
         "nv-device-os: WINDOWS",
@@ -681,7 +683,8 @@ SessionInfo GfnClient::StartSession(AuthSession& session, const std::string& lau
         "Referer: https://play.geforcenow.com/"
     };
 
-    std::string body = BuildSessionBody(launch_app_id, internal_title, device_id, stream_settings);
+    std::string body = BuildSessionBody(
+        launch_app_id, internal_title, device_id, sub_session_id, stream_settings);
     ResetSessionTraceLog("StartSession appId=" + launch_app_id +
                          " store=" + (launch_store.empty() ? "unknown" : launch_store) +
                          " internalTitle=" + (internal_title.empty() ? "missing" : internal_title));
@@ -786,7 +789,7 @@ SessionInfo GfnClient::PollSession(AuthSession& session, const std::string& sess
 {
     session = EnsureFreshSavedSession(session);
     std::string jwt_token = ResolveSessionJwt(session);
-    const std::string device_id = device_id_;
+    const std::string device_id = GenerateDeviceId();
     std::string url = session.provider.streaming_service_url + "v2/session/" + session_id;
 
     std::vector<std::string> headers = {
@@ -795,7 +798,7 @@ SessionInfo GfnClient::PollSession(AuthSession& session, const std::string& sess
         "nv-browser-type: CHROME",
         "nv-client-streamer: NVIDIA-CLASSIC",
         "nv-client-type: NATIVE",
-        "nv-client-version: 30.0",
+        "nv-client-version: 2.0.80.173",
         "nv-device-make: UNKNOWN",
         "nv-device-model: UNKNOWN",
         "nv-device-os: WINDOWS",
@@ -894,7 +897,7 @@ void GfnClient::StopSession(AuthSession& session, const std::string& session_id)
 {
     session = EnsureFreshSavedSession(session);
     std::string jwt_token = ResolveSessionJwt(session);
-    const std::string device_id = device_id_;
+    const std::string device_id = GenerateDeviceId();
     std::string url = session.provider.streaming_service_url + "v2/session/" + session_id;
 
     std::vector<std::string> headers = {
@@ -903,7 +906,7 @@ void GfnClient::StopSession(AuthSession& session, const std::string& session_id)
         "nv-browser-type: CHROME",
         "nv-client-streamer: NVIDIA-CLASSIC",
         "nv-client-type: NATIVE",
-        "nv-client-version: 30.0",
+        "nv-client-version: 2.0.80.173",
         "nv-device-make: UNKNOWN",
         "nv-device-model: UNKNOWN",
         "nv-device-os: WINDOWS",
@@ -941,7 +944,22 @@ void GfnClient::CleanupStaleCloudSession(AuthSession& session) const
         return;
 
     AppendAuthLog("session: cleaning stale CloudMatch session before launch");
-    StopSession(session, stale_session_id);
+    try
+    {
+        StopSession(session, stale_session_id);
+    }
+    catch (const std::exception& e)
+    {
+        const std::string error = e.what();
+        if (error.find("HTTP 403") == std::string::npos)
+            throw;
+
+        // Builds before the stable-device fix created CloudMatch sessions with
+        // a shared placeholder identity. They cannot be deleted with the new,
+        // installation-specific identity and must not block the next launch.
+        AppendAuthLog("session: discarded legacy stale-session marker after HTTP 403");
+        ForgetActiveCloudSession(stale_session_id);
+    }
 }
 
 

--- a/app/src/gfn/internal.hpp
+++ b/app/src/gfn/internal.hpp
@@ -28,6 +28,7 @@ std::string EnsureTrailingSlash(std::string value);
 LoginProvider DefaultProvider();
 std::vector<unsigned char> GenerateRandomBytes(size_t length);
 std::string HexEncode(const unsigned char* data, size_t length);
+std::string GenerateUuid();
 std::string GenerateDeviceId();
 std::string UrlEncode(const std::string& input, bool plus_for_space = false);
 std::string ReadTextFile(const std::string& path);

--- a/app/src/gfn/persistence.cpp
+++ b/app/src/gfn/persistence.cpp
@@ -207,12 +207,19 @@ bool ParseSessionObject(json_t* root, AuthSession& session)
     session.user.email           = GetString(user, "email");
     session.user.avatar_url      = GetString(user, "avatar_url");
     session.user.membership_tier = GetString(user, "membership_tier");
-    if (session.user.membership_tier.empty())
-        session.user.membership_tier = "FREE";
+    session.user.membership_tier_verified =
+        GetBool(user, "membership_tier_verified", false);
 
     json_t* last_refresh = json_object_get(root, "last_refresh_at_ms");
     if (json_is_integer(last_refresh))
         session.last_refresh_at_ms = static_cast<std::int64_t>(json_integer_value(last_refresh));
+
+    json_t* membership_checked = json_object_get(root, "membership_checked_at_ms");
+    if (json_is_integer(membership_checked))
+    {
+        session.membership_checked_at_ms =
+            static_cast<std::int64_t>(json_integer_value(membership_checked));
+    }
 
     if (session.provider.idp_id.empty())
         session.provider = DefaultProvider();
@@ -251,11 +258,17 @@ JsonPtr BuildSessionObject(const AuthSession& session)
     json_object_set_new(user.get(), "email", json_string(session.user.email.c_str()));
     json_object_set_new(user.get(), "avatar_url", json_string(session.user.avatar_url.c_str()));
     json_object_set_new(user.get(), "membership_tier", json_string(session.user.membership_tier.c_str()));
+    json_object_set_new(
+        user.get(), "membership_tier_verified",
+        json_boolean(session.user.membership_tier_verified));
 
     json_object_set_new(root.get(), "provider", json_incref(provider.get()));
     json_object_set_new(root.get(), "tokens", json_incref(tokens.get()));
     json_object_set_new(root.get(), "user", json_incref(user.get()));
     json_object_set_new(root.get(), "last_refresh_at_ms", json_integer(session.last_refresh_at_ms));
+    json_object_set_new(
+        root.get(), "membership_checked_at_ms",
+        json_integer(session.membership_checked_at_ms));
     return root;
 }
 std::vector<NativeCredentials> LoadNativeCredentialEntries()
@@ -428,7 +441,7 @@ void SaveAccountsToDisk(const std::vector<AuthSession>& sessions, const std::str
         json_array_append_new(accounts.get(), json_incref(item.get()));
     }
 
-    json_object_set_new(root.get(), "schema_version", json_integer(3));
+    json_object_set_new(root.get(), "schema_version", json_integer(4));
     json_object_set_new(root.get(), "active_user_id", json_string(active_user_id.c_str()));
     json_object_set_new(root.get(), "accounts", json_incref(accounts.get()));
     char* dump = json_dumps(root.get(), JSON_COMPACT | JSON_SORT_KEYS);

--- a/app/src/gfn/shared.cpp
+++ b/app/src/gfn/shared.cpp
@@ -1,5 +1,6 @@
 #include "internal.hpp"
 
+#include "../device_identity_policy.hpp"
 #include "../stream_diagnostics.hpp"
 
 #ifdef __SWITCH__
@@ -163,15 +164,24 @@ std::string HexEncode(const unsigned char* data, size_t length)
     return output;
 }
 
+std::string GenerateUuid()
+{
+    auto bytes = GenerateRandomBytes(16);
+    bytes[6] = static_cast<unsigned char>((bytes[6] & 0x0f) | 0x40);
+    bytes[8] = static_cast<unsigned char>((bytes[8] & 0x3f) | 0x80);
+    const std::string hex = HexEncode(bytes.data(), bytes.size());
+    return hex.substr(0, 8) + "-" + hex.substr(8, 4) + "-" + hex.substr(12, 4) +
+        "-" + hex.substr(16, 4) + "-" + hex.substr(20);
+}
+
 std::string GenerateDeviceId()
 {
     const std::string path = GetAppHome() + "/device_id.txt";
     std::string stored = Trim(ReadTextFile(path));
-    if (!stored.empty())
+    if (device_identity::IsUsableStoredDeviceId(stored))
         return stored;
 
-    const auto bytes = GenerateRandomBytes(32);
-    stored           = HexEncode(bytes.data(), bytes.size());
+    stored = GenerateUuid();
     WriteTextFileAtomically(path, stored);
     return stored;
 }
@@ -368,3 +378,13 @@ std::string ResolveSessionJwt(const AuthSession& session)
 }
 
 } // namespace opennow::gfn::detail
+
+namespace opennow
+{
+
+GfnClient::GfnClient()
+    : client_id_(gfn::detail::GenerateUuid())
+{
+}
+
+} // namespace opennow

--- a/app/src/gfn_client.hpp
+++ b/app/src/gfn_client.hpp
@@ -26,6 +26,8 @@ class NativeLoginFallbackRequired : public std::runtime_error
 class GfnClient
 {
   public:
+    GfnClient();
+
     std::vector<LoginProvider> FetchLoginProviders() const;
     std::vector<PublicGame> FetchPublicGames() const;
     std::vector<PublicGame> FetchCatalogGames(
@@ -82,8 +84,7 @@ class GfnClient
 
   private:
     HttpClient http_client_;
-    std::string client_id_ = "d54a2a22-386f-4a30-84dc-6680a6b7d188";
-    std::string device_id_ = "12345678-1234-5678-1234-567812345678";
+    std::string client_id_;
 };
 
 } // namespace opennow

--- a/app/src/library_tab.cpp
+++ b/app/src/library_tab.cpp
@@ -11,6 +11,7 @@
 #include "ui_text_policy.hpp"
 #include "qr_login_dialog.hpp"
 #include "localization.hpp"
+#include "membership_tier_policy.hpp"
 
 #include <algorithm>
 #include <array>
@@ -296,8 +297,8 @@ void LibraryTab::UpdateSessionUi()
     }
 
     const AuthSession& session = *state.session();
-    const std::string membership =
-        session.user.membership_tier.empty() ? std::string("FREE") : session.user.membership_tier;
+    const std::string membership = membership::DisplayLabel(
+        session.user.membership_tier, session.user.membership_tier_verified);
 
     if (session.reauthentication_required)
     {
@@ -309,7 +310,7 @@ void LibraryTab::UpdateSessionUi()
     else
     {
         account_label_->setText(
-            "Connected as " + session.user.display_name + "  |  " + membership + " tier");
+            "Connected as " + session.user.display_name + "  |  " + membership);
         sign_in_button_->setText(Tr("Add another account"));
         refresh_button_->setState(brls::ButtonState::ENABLED);
     }

--- a/app/src/membership_tier_policy.hpp
+++ b/app/src/membership_tier_policy.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace opennow::membership
+{
+
+inline std::string DisplayLabel(const std::string& tier, bool verified)
+{
+    if (!verified || tier.empty())
+        return "Membership unavailable";
+    return tier;
+}
+
+} // namespace opennow::membership

--- a/app/src/models.hpp
+++ b/app/src/models.hpp
@@ -32,7 +32,8 @@ struct AuthUser
     std::string display_name;
     std::string email;
     std::string avatar_url;
-    std::string membership_tier = "FREE";
+    std::string membership_tier;
+    bool membership_tier_verified = false;
 };
 
 struct AuthSession
@@ -41,6 +42,7 @@ struct AuthSession
     AuthTokens tokens;
     AuthUser user;
     std::int64_t last_refresh_at_ms = 0;
+    std::int64_t membership_checked_at_ms = 0;
     bool persistence_enabled = true; // Runtime-only; vault sessions are persistent.
     bool reauthentication_required = false; // Runtime-only; set after invalid_grant/401 refresh failure.
 };

--- a/app/src/session_error_policy.hpp
+++ b/app/src/session_error_policy.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+
+namespace opennow::session_error
+{
+
+struct Presentation
+{
+    std::string title;
+    std::string body;
+};
+
+inline bool Contains(const std::string& value, const char* needle)
+{
+    return value.find(needle) != std::string::npos;
+}
+
+inline Presentation Present(const std::string& error)
+{
+    if (Contains(error, "SESSION_LIMIT_PER_DEVICE_EXCEEDED") ||
+        Contains(error, "statusCode=50"))
+    {
+        return {
+            "A session is already active",
+            "GeForce NOW still has a session attached to this device. End the other session, "
+            "wait a moment, and try again.",
+        };
+    }
+
+    if (Contains(error, "SESSION_LIMIT") || Contains(error, "statusCode=51"))
+    {
+        return {
+            "Your account is already streaming",
+            "End the active GeForce NOW session on the other device, then try again.",
+        };
+    }
+
+    if (Contains(error, "statusCode=81") || Contains(error, "membership"))
+    {
+        return {
+            "Membership required",
+            "This game is not included with the current GeForce NOW membership.",
+        };
+    }
+
+    if (Contains(error, "HTTP 401") || Contains(error, "sign in again") ||
+        Contains(error, "login is no longer valid"))
+    {
+        return {
+            "Sign in again",
+            "Your NVIDIA authorization expired. Open Library and sign in to this account again.",
+        };
+    }
+
+    std::string concise = error;
+    const size_t diagnostics = concise.find("\nEnable Settings");
+    if (diagnostics != std::string::npos)
+        concise.erase(diagnostics);
+    const size_t details = concise.find("\nDetails:");
+    if (details != std::string::npos)
+        concise.erase(details);
+    if (concise.size() > 280)
+        concise = concise.substr(0, 277) + "...";
+
+    return {
+        "Session could not start",
+        concise.empty() ? "GeForce NOW did not start the session. Please try again." : concise,
+    };
+}
+
+} // namespace opennow::session_error

--- a/app/src/settings_tab.cpp
+++ b/app/src/settings_tab.cpp
@@ -3,6 +3,7 @@
 #include "app_state.hpp"
 #include "app_paths.hpp"
 #include "localization.hpp"
+#include "membership_tier_policy.hpp"
 #include "network_utils.hpp"
 #include "stream_settings.hpp"
 #include "stream_settings_policy.hpp"
@@ -521,7 +522,10 @@ void SettingsTab::BuildAccountPage()
         const AuthSession& session = *state.session();
         const bool password_saved = client_.LoadNativeCredentials(session.provider.idp_id).has_value();
         AddInfoLine(overview, "User", session.user.display_name);
-        AddInfoLine(overview, "Membership", session.user.membership_tier.empty() ? "Unknown" : session.user.membership_tier);
+        AddInfoLine(
+            overview, "Membership",
+            membership::DisplayLabel(
+                session.user.membership_tier, session.user.membership_tier_verified));
         AddInfoLine(overview, "Provider", session.provider.display_name);
         AddInfoLine(overview, "Authentication", FormatTokenState(session));
         AddInfoLine(overview, "Quick sign-in", password_saved ? "Password saved" : "Password not saved");
@@ -860,7 +864,8 @@ bool SettingsTab::ShowSessionDialog(brls::View* view)
         "Session Details",
         "User: " + session.user.display_name + "\n" +
             "Email: " + (session.user.email.empty() ? std::string("Unavailable") : session.user.email) + "\n" +
-            "Tier: " + session.user.membership_tier + "\n" +
+            "Tier: " + membership::DisplayLabel(
+                session.user.membership_tier, session.user.membership_tier_verified) + "\n" +
             "Provider: " + session.provider.display_name + "\n" +
             "Authentication: " + FormatTokenState(session) + "\n" +
             "Streaming base: " + session.provider.streaming_service_url + "\n" +

--- a/app/src/top_bar_frame.cpp
+++ b/app/src/top_bar_frame.cpp
@@ -4,6 +4,7 @@
 #include "cover_image_cache.hpp"
 #include "stream_settings.hpp"
 #include "localization.hpp"
+#include "membership_tier_policy.hpp"
 #include "ui_refresh_policy.hpp"
 #include <borealis/core/application.hpp>
 #include <borealis/core/theme.hpp>
@@ -15,7 +16,7 @@ TopBarFrame::TopBarFrame()
     : brls::Box(brls::Axis::COLUMN)
 {
     setGrow(1.0f);
-    setBackgroundColor(nvgRGB(16, 16, 20));
+    setBackgroundColor(nvgRGB(18, 18, 22));
 
     // Header container
     header_container_ = new brls::Box(brls::Axis::ROW);
@@ -23,7 +24,7 @@ TopBarFrame::TopBarFrame()
     header_container_->setAlignItems(brls::AlignItems::CENTER);
     header_container_->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
     header_container_->setPadding(0, 28, 0, 28);
-    header_container_->setBackgroundColor(nvgRGB(19, 19, 22));
+    header_container_->setBackgroundColor(nvgRGB(24, 24, 29));
     
     addView(header_container_);
 
@@ -32,11 +33,11 @@ TopBarFrame::TopBarFrame()
     brand->setJustifyContent(brls::JustifyContent::CENTER);
     auto* brand_name = new brls::Label();
     brand_name->setText("OpenNOW");
-    brand_name->setFontSize(24);
-    brand_name->setTextColor(nvgRGB(88, 217, 138));
+    brand_name->setFontSize(22);
+    brand_name->setTextColor(nvgRGB(0, 200, 215));
     brand->addView(brand_name);
     auto* brand_platform = new brls::Label();
-    brand_platform->setText("NINTENDO SWITCH");
+    brand_platform->setText("Nintendo Switch");
     brand_platform->setFontSize(10);
     brand_platform->setTextColor(nvgRGB(112, 119, 130));
     brand->addView(brand_platform);
@@ -85,7 +86,7 @@ TopBarFrame::TopBarFrame()
     // Divider
     auto* divider = new brls::Rectangle();
     divider->setHeight(1);
-    divider->setColor(nvgRGB(42, 42, 48));
+    divider->setColor(nvgRGBA(255, 255, 255, 18));
     addView(divider);
 
     // Content container
@@ -149,7 +150,7 @@ void TopBarFrame::addTab(const std::string& label, TabViewCreator creator)
 
     auto* text = new brls::Label();
     text->setText(Tr(label));
-    text->setFontSize(20);
+    text->setFontSize(18);
     text->setTextColor(nvgRGB(128, 133, 143));
     tab_box->addView(text);
 
@@ -218,7 +219,7 @@ void TopBarFrame::SelectTab(int index)
     for (size_t i = 0; i < tabs_.size(); ++i) {
         if ((int)i == index) {
             tabs_[i].header_label->setTextColor(nvgRGB(255, 255, 255));
-            tabs_[i].underline->setColor(nvgRGB(96, 236, 136));
+            tabs_[i].underline->setColor(nvgRGB(0, 200, 215));
             tabs_[i].tab_box->setBackgroundColor(nvgRGB(31, 34, 40));
         } else {
             tabs_[i].header_label->setTextColor(nvgRGB(128, 133, 143));
@@ -264,7 +265,7 @@ void TopBarFrame::UpdateStatusBar(bool force)
     {
         avatar_image_->setVisibility(brls::Visibility::GONE);
         const std::string name = Tr("Guest");
-        const std::string detail = Tr("No account") + "  ·  " + Tr(settings.label);
+        const std::string detail = Tr("No account") + "  /  " + Tr(settings.label);
         const std::string status = name + "\n" + detail;
         if (status != displayed_status_)
         {
@@ -276,10 +277,11 @@ void TopBarFrame::UpdateStatusBar(bool force)
     }
 
     const AuthSession& session = *state.session();
-    const std::string tier = session.user.membership_tier.empty() ? std::string("FREE") : session.user.membership_tier;
+    const std::string tier = membership::DisplayLabel(
+        session.user.membership_tier, session.user.membership_tier_verified);
     const std::string name =
         session.user.display_name.empty() ? Tr("GeForce NOW account") : session.user.display_name;
-    const std::string detail = tier + "  ·  " + Tr(settings.label);
+    const std::string detail = Tr(tier) + "  /  " + Tr(settings.label);
     const std::string status = name + "\n" + detail;
     if (status != displayed_status_)
     {

--- a/app/src/ui_helpers.cpp
+++ b/app/src/ui_helpers.cpp
@@ -3,6 +3,7 @@
 #include "app_state.hpp"
 #include "cover_image_cache.hpp"
 #include "play_history.hpp"
+#include "session_error_policy.hpp"
 #include "localization.hpp"
 #include <borealis.hpp>
 #include <switch.h>
@@ -52,7 +53,7 @@ class LaunchAnimationView final : public brls::View
         const double seconds = std::chrono::duration<double>(
             std::chrono::steady_clock::now().time_since_epoch()).count();
         const float pulse = 0.5f + 0.5f * static_cast<float>(std::sin(seconds * 3.2));
-        static constexpr const char* kLabels[] = {"QUEUE", "SETUP", "READY"};
+        static constexpr const char* kLabels[] = {"Queue", "Setup", "Ready"};
         const float rail_y = y + 42.0f;
         const float first_x = x + 76.0f;
         const float gap = (width - 152.0f) * 0.5f;
@@ -69,7 +70,7 @@ class LaunchAnimationView final : public brls::View
             completed_width = gap * 2.0f;
         nvgBeginPath(vg);
         nvgRect(vg, first_x, rail_y - 2.0f, completed_width, 4.0f);
-        nvgFillColor(vg, nvgRGB(77, 218, 130));
+        nvgFillColor(vg, nvgRGB(0, 200, 215));
         nvgFill(vg);
 
         nvgFontFaceId(vg, brls::Application::getFont(brls::FONT_REGULAR));
@@ -83,15 +84,15 @@ class LaunchAnimationView final : public brls::View
             {
                 nvgBeginPath(vg);
                 nvgCircle(vg, cx, rail_y, 29.0f + pulse * 3.0f);
-                nvgFillColor(vg, nvgRGBA(77, 218, 130, 25 + static_cast<int>(pulse * 22.0f)));
+                nvgFillColor(vg, nvgRGBA(0, 200, 215, 25 + static_cast<int>(pulse * 22.0f)));
                 nvgFill(vg);
             }
             nvgBeginPath(vg);
             nvgCircle(vg, cx, rail_y, 22.0f);
-            nvgFillColor(vg, complete || active ? nvgRGB(77, 218, 130) : nvgRGB(24, 28, 33));
+            nvgFillColor(vg, complete || active ? nvgRGB(0, 200, 215) : nvgRGB(24, 28, 33));
             nvgFill(vg);
             nvgStrokeWidth(vg, 2.0f);
-            nvgStrokeColor(vg, complete || active ? nvgRGB(108, 235, 153) : nvgRGB(43, 48, 55));
+            nvgStrokeColor(vg, complete || active ? nvgRGB(100, 231, 239) : nvgRGB(43, 48, 55));
             nvgStroke(vg);
 
             nvgFontSize(vg, 17.0f);
@@ -117,13 +118,13 @@ class LaunchAnimationView final : public brls::View
                angle + kPi * 1.42f, NVG_CW);
         nvgStrokeWidth(vg, 5.0f);
         nvgLineCap(vg, NVG_ROUND);
-        nvgStrokeColor(vg, nvgRGB(77, 218, 130));
+        nvgStrokeColor(vg, nvgRGB(0, 200, 215));
         nvgStroke(vg);
         const float head_angle = angle + kPi * 1.42f;
         nvgBeginPath(vg);
         nvgCircle(vg, spinner_x + std::cos(head_angle) * 18.0f,
                   spinner_y + std::sin(head_angle) * 18.0f, 3.2f);
-        nvgFillColor(vg, nvgRGB(123, 242, 166));
+        nvgFillColor(vg, nvgRGB(118, 234, 241));
         nvgFill(vg);
     }
 
@@ -149,7 +150,7 @@ void SetLaunchProgress(
         const bool queue_position = title.rfind("Position in queue:", 0) == 0;
         stage_label->setFontSize(queue_position ? 36 : 27);
         stage_label->setTextColor(queue_position
-            ? nvgRGB(98, 232, 148)
+            ? nvgRGB(0, 200, 215)
             : nvgRGB(238, 242, 245));
     }
     if (detail_label)
@@ -210,8 +211,7 @@ void LaunchSessionDialog(const GfnClient& client, const AuthSession& auth,
     box->setWidth(720);
     box->setPadding(24, 36, 18, 36);
     box->setAlignItems(brls::AlignItems::CENTER);
-    box->setBackgroundColor(nvgRGB(15, 17, 21));
-    box->setCornerRadius(18);
+    box->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
 
     auto* game_header = new brls::Box(brls::Axis::ROW);
     game_header->setWidth(620);
@@ -231,9 +231,9 @@ void LaunchSessionDialog(const GfnClient& client, const AuthSession& auth,
     auto* game_copy = new brls::Box(brls::Axis::COLUMN);
     game_copy->setGrow(1.0f);
     auto* eyebrow = new brls::Label();
-    eyebrow->setText(Tr("NOW LOADING"));
+    eyebrow->setText(Tr("Now loading"));
     eyebrow->setFontSize(13);
-    eyebrow->setTextColor(nvgRGB(77, 218, 130));
+    eyebrow->setTextColor(nvgRGB(0, 200, 215));
     eyebrow->setMarginBottom(5);
     game_copy->addView(eyebrow);
     auto* heading = new brls::Label();
@@ -424,13 +424,16 @@ void LaunchSessionDialog(const GfnClient& client, const AuthSession& auth,
             });
 
         } catch (const std::exception& e) {
-            std::string err = e.what();
+            const session_error::Presentation error = session_error::Present(e.what());
             brls::sync([=]() {
                 if (!launch_state->running) return;
                 animation->SetState(0, 0.04f);
-                stage_label->setText(Tr("Session could not start"));
+                stage_label->setText(Tr(error.title));
+                stage_label->setFontSize(24);
                 stage_label->setTextColor(nvgRGB(255, 125, 132));
-                detail_label->setText(err + "\n\nPress B to return to the game page.");
+                detail_label->setFontSize(17);
+                detail_label->setText(
+                    Tr(error.body) + "\n\n" + Tr("Press B to return to the game page."));
                 dialog->setCancelable(true);
             });
         }

--- a/tests/device_identity_policy_test.cpp
+++ b/tests/device_identity_policy_test.cpp
@@ -1,0 +1,15 @@
+#include "device_identity_policy.hpp"
+
+#include <cassert>
+
+static_assert(!opennow::device_identity::IsUsableStoredDeviceId(""));
+static_assert(!opennow::device_identity::IsUsableStoredDeviceId(
+    "12345678-1234-5678-1234-567812345678"));
+static_assert(opennow::device_identity::IsUsableStoredDeviceId(
+    "2b14829e-1bd6-49b9-8e92-cf25d03492c4"));
+
+int main()
+{
+    assert(opennow::device_identity::IsUsableStoredDeviceId("legacy-unique-id"));
+    return 0;
+}

--- a/tests/membership_tier_policy_test.cpp
+++ b/tests/membership_tier_policy_test.cpp
@@ -1,0 +1,13 @@
+#include "membership_tier_policy.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using opennow::membership::DisplayLabel;
+    assert(DisplayLabel("ULTIMATE", true) == "ULTIMATE");
+    assert(DisplayLabel("FREE", true) == "FREE");
+    assert(DisplayLabel("FREE", false) == "Membership unavailable");
+    assert(DisplayLabel("", false) == "Membership unavailable");
+    return 0;
+}

--- a/tests/session_error_policy_test.cpp
+++ b/tests/session_error_policy_test.cpp
@@ -1,0 +1,23 @@
+#include "session_error_policy.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using opennow::session_error::Present;
+
+    const auto device_limit = Present(
+        "StartSession failed: HTTP 403, statusCode=50, "
+        "statusDescription=SESSION_LIMIT_PER_DEVICE_EXCEEDED_STATUS");
+    assert(device_limit.title == "A session is already active");
+    assert(device_limit.body.find("statusCode") == std::string::npos);
+
+    const auto auth = Present("StartSession failed: HTTP 401");
+    assert(auth.title == "Sign in again");
+
+    const auto generic = Present(
+        "Network request failed\nEnable Settings > Stream > Debug diagnostics");
+    assert(generic.title == "Session could not start");
+    assert(generic.body == "Network request failed");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Improve saved-session recovery with client-token and OAuth refresh fallbacks.
- Preserve refreshed JWTs and handle reauthentication-required errors clearly.
- Resolve and persist verified GeForce NOW membership tiers with periodic refreshes.
- Generate valid device and sub-session IDs, including legacy-session recovery.
- Update account, membership, launch-error, and top-bar UI presentation.
- Add policy coverage for device identity, membership labels, and session errors.

## Testing

- Added host-side tests for device identity, membership tier, and session error policies.
- Not run: host test compilation/execution.
- Not run: Nintendo Switch build and hardware login/session validation.