### PR TITLE
Add optional community proxy routing

### DIFF
--- a/app/src/community_proxy_policy.hpp
+++ b/app/src/community_proxy_policy.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "stream_settings.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <string_view>
+
+namespace opennow::community_proxy
+{
+
+inline constexpr std::string_view kHost = "opennow-proxy-tcp.zortos.me";
+inline constexpr std::string_view kFallbackHost = "217.76.50.166";
+inline constexpr std::string_view kPort = "3128";
+inline constexpr std::string_view kProvisionUrl =
+    "https://opennow-proxy.zortos.me/api/public/proxy";
+
+inline std::string Trim(std::string_view value)
+{
+    const auto first = std::find_if_not(value.begin(), value.end(), [](unsigned char ch) {
+        return std::isspace(ch) != 0;
+    });
+    const auto last = std::find_if_not(value.rbegin(), value.rend(), [](unsigned char ch) {
+        return std::isspace(ch) != 0;
+    }).base();
+    return first < last ? std::string(first, last) : std::string();
+}
+
+inline std::string NormalizeUrl(std::string_view raw)
+{
+    std::string value = Trim(raw);
+    if (!value.empty() && value.find("://") == std::string::npos)
+        value.insert(0, "http://");
+    return value;
+}
+
+inline bool IsCommunityProxyUrl(std::string_view raw)
+{
+    const std::string value = NormalizeUrl(raw);
+    constexpr std::string_view scheme = "http://";
+    if (value.size() <= scheme.size() ||
+        !std::equal(scheme.begin(), scheme.end(), value.begin(), [](char left, char right) {
+            return std::tolower(static_cast<unsigned char>(left)) ==
+                   std::tolower(static_cast<unsigned char>(right));
+        }))
+        return false;
+
+    const size_t authority_end = value.find_first_of("/?#", scheme.size());
+    if (authority_end != std::string::npos &&
+        !(authority_end + 1 == value.size() && value[authority_end] == '/'))
+        return false;
+
+    const std::string authority = value.substr(
+        scheme.size(),
+        authority_end == std::string::npos ? std::string::npos : authority_end - scheme.size());
+    const size_t at = authority.rfind('@');
+    if (at == std::string::npos || at == 0 || at + 1 >= authority.size())
+        return false;
+
+    std::string endpoint = authority.substr(at + 1);
+    std::transform(endpoint.begin(), endpoint.end(), endpoint.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return endpoint == std::string(kHost) + ":" + std::string(kPort) ||
+           endpoint == std::string(kFallbackHost) + ":" + std::string(kPort);
+}
+
+inline std::string EnabledUrl(const StreamSettings& settings)
+{
+    if (!settings.community_proxy_enabled || !IsCommunityProxyUrl(settings.community_proxy_url))
+        return {};
+    return NormalizeUrl(settings.community_proxy_url);
+}
+
+} // namespace opennow::community_proxy

--- a/app/src/device_identity_policy.hpp
+++ b/app/src/device_identity_policy.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string_view>
 
 namespace opennow::device_identity
@@ -7,6 +8,29 @@ namespace opennow::device_identity
 
 constexpr std::string_view kLegacyPlaceholderId =
     "12345678-1234-5678-1234-567812345678";
+
+constexpr bool IsHexDigit(char value)
+{
+    return (value >= '0' && value <= '9') ||
+           (value >= 'a' && value <= 'f') ||
+           (value >= 'A' && value <= 'F');
+}
+
+constexpr bool IsCanonicalUuid(std::string_view value)
+{
+    if (value.size() != 36 || value[8] != '-' || value[13] != '-' ||
+        value[18] != '-' || value[23] != '-')
+        return false;
+
+    for (std::size_t index = 0; index < value.size(); ++index)
+    {
+        if (index == 8 || index == 13 || index == 18 || index == 23)
+            continue;
+        if (!IsHexDigit(value[index]))
+            return false;
+    }
+    return true;
+}
 
 constexpr bool IsUsableStoredDeviceId(std::string_view value)
 {

--- a/app/src/gfn/catalog.cpp
+++ b/app/src/gfn/catalog.cpp
@@ -1,6 +1,8 @@
 #include "internal.hpp"
 
+#include "../community_proxy_policy.hpp"
 #include "../play_history.hpp"
+#include "../stream_settings.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -265,12 +267,16 @@ std::string BuildLibraryUrl(const std::string& vpc_id, bool with_library_time)
     return url;
 }
 
-std::string ResolveVpcId(const HttpClient& http_client, const AuthSession& session)
+std::string ResolveVpcId(
+    const HttpClient& http_client,
+    const AuthSession& session,
+    const std::string& proxy_url)
 {
     const HttpResponse response = http_client.Get(
         EnsureTrailingSlash(session.provider.streaming_service_url) + "v2/serverInfo",
         GfnClient::kUserAgent,
-        BuildGfnLcarsHeaders(ResolveSessionJwt(session), "NATIVE", "NVIDIA-CLASSIC", true));
+        BuildGfnLcarsHeaders(ResolveSessionJwt(session), "NATIVE", "NVIDIA-CLASSIC", true),
+        proxy_url);
 
     if (response.status_code != 200)
         return "GFN-PC";
@@ -543,10 +549,12 @@ std::vector<LoginProvider> GfnClient::FetchLoginProviders() const
 
 std::vector<PublicGame> GfnClient::FetchPublicGames() const
 {
+    const std::string proxy_url = community_proxy::EnabledUrl(LoadStreamSettings());
     const HttpResponse response = http_client_.Get(
         kPublicCatalogEndpoint,
         kUserAgent,
-        {"Accept: application/json"});
+        {"Accept: application/json"},
+        proxy_url);
 
     if (response.status_code != 200)
     {
@@ -596,7 +604,8 @@ std::vector<PublicGame> GfnClient::FetchCatalogGames(
 {
     session = RecoverSavedSession(session);
     std::string jwt_token = ResolveSessionJwt(session);
-    const std::string vpc_id = ResolveVpcId(http_client_, session);
+    const std::string proxy_url = community_proxy::EnabledUrl(LoadStreamSettings());
+    const std::string vpc_id = ResolveVpcId(http_client_, session, proxy_url);
 
     std::vector<PublicGame> games;
     std::unordered_set<std::string> seen_ids;
@@ -608,7 +617,8 @@ std::vector<PublicGame> GfnClient::FetchCatalogGames(
             kGraphQlEndpoint,
             kUserAgent,
             BuildGraphQlPostHeaders(jwt_token),
-            BuildCatalogRequestBody(vpc_id, search_query, cursor));
+            BuildCatalogRequestBody(vpc_id, search_query, cursor),
+            proxy_url);
 
         if (response.status_code == 401)
         {
@@ -618,7 +628,8 @@ std::vector<PublicGame> GfnClient::FetchCatalogGames(
                 kGraphQlEndpoint,
                 kUserAgent,
                 BuildGraphQlPostHeaders(jwt_token),
-                BuildCatalogRequestBody(vpc_id, search_query, cursor));
+                BuildCatalogRequestBody(vpc_id, search_query, cursor),
+                proxy_url);
         }
 
         if (response.status_code != 200)
@@ -650,12 +661,14 @@ std::vector<GameInfo> GfnClient::FetchLibraryGames(AuthSession& session) const
 {
     session = RecoverSavedSession(session);
     std::string jwt_token = ResolveSessionJwt(session);
-    const std::string vpc_id    = ResolveVpcId(http_client_, session);
+    const std::string proxy_url = community_proxy::EnabledUrl(LoadStreamSettings());
+    const std::string vpc_id = ResolveVpcId(http_client_, session, proxy_url);
 
     HttpResponse response = http_client_.Get(
         BuildLibraryUrl(vpc_id, true),
         kUserAgent,
-        BuildGraphQlHeaders(jwt_token));
+        BuildGraphQlHeaders(jwt_token),
+        proxy_url);
 
     if (response.status_code == 401)
     {
@@ -664,7 +677,8 @@ std::vector<GameInfo> GfnClient::FetchLibraryGames(AuthSession& session) const
         response = http_client_.Get(
             BuildLibraryUrl(vpc_id, true),
             kUserAgent,
-            BuildGraphQlHeaders(jwt_token));
+            BuildGraphQlHeaders(jwt_token),
+            proxy_url);
     }
 
     if (response.status_code != 200)
@@ -672,7 +686,8 @@ std::vector<GameInfo> GfnClient::FetchLibraryGames(AuthSession& session) const
         response = http_client_.Get(
             BuildLibraryUrl(vpc_id, false),
             kUserAgent,
-            BuildGraphQlHeaders(jwt_token));
+            BuildGraphQlHeaders(jwt_token),
+            proxy_url);
     }
 
     if (response.status_code != 200)

--- a/app/src/gfn/cloud_session.cpp
+++ b/app/src/gfn/cloud_session.cpp
@@ -1,5 +1,6 @@
 #include "internal.hpp"
 
+#include "../community_proxy_policy.hpp"
 #include "../stream_diagnostics.hpp"
 #include "../stream_settings.hpp"
 
@@ -662,6 +663,7 @@ SessionInfo GfnClient::StartSession(AuthSession& session, const std::string& lau
     const std::string sub_session_id = GenerateUuid();
 
     const StreamSettings stream_settings = LoadStreamSettings();
+    const std::string proxy_url = community_proxy::EnabledUrl(stream_settings);
     std::string url = session.provider.streaming_service_url +
         "v2/session?keyboardLayout=en-US_qwerty&languageCode=" +
         stream_settings.game_language;
@@ -700,14 +702,14 @@ SessionInfo GfnClient::StartSession(AuthSession& session, const std::string& lau
     AppendSessionTraceLog("START headers:\n" + HeadersForTrace(headers));
     AppendSessionTraceLog("START request body:\n" + JsonForTrace(body));
 
-    HttpResponse response = http_client_.Post(url, kUserAgent, headers, body);
+    HttpResponse response = http_client_.Post(url, kUserAgent, headers, body, proxy_url);
     if (response.status_code == 401)
     {
         session = ForceRefreshSavedSession(session);
         jwt_token = ResolveSessionJwt(session);
         headers[0] = "Authorization: GFNJWT " + jwt_token;
         AppendSessionTraceLog("START authorization rejected; refreshed token and retrying once");
-        response = http_client_.Post(url, kUserAgent, headers, body);
+        response = http_client_.Post(url, kUserAgent, headers, body, proxy_url);
     }
     AppendSessionTraceLog("START response HTTP " + std::to_string(response.status_code));
     AppendSessionTraceLog("START response body:\n" + JsonForTrace(response.body));
@@ -790,6 +792,7 @@ SessionInfo GfnClient::PollSession(AuthSession& session, const std::string& sess
     session = EnsureFreshSavedSession(session);
     std::string jwt_token = ResolveSessionJwt(session);
     const std::string device_id = GenerateDeviceId();
+    const std::string proxy_url = community_proxy::EnabledUrl(LoadStreamSettings());
     std::string url = session.provider.streaming_service_url + "v2/session/" + session_id;
 
     std::vector<std::string> headers = {
@@ -809,14 +812,14 @@ SessionInfo GfnClient::PollSession(AuthSession& session, const std::string& sess
 
     AppendSessionTraceLog("POLL url=" + url);
     AppendSessionTraceLog("POLL headers:\n" + HeadersForTrace(headers));
-    HttpResponse response = http_client_.Get(url, kUserAgent, headers);
+    HttpResponse response = http_client_.Get(url, kUserAgent, headers, proxy_url);
     if (response.status_code == 401)
     {
         session = ForceRefreshSavedSession(session);
         jwt_token = ResolveSessionJwt(session);
         headers[0] = "Authorization: GFNJWT " + jwt_token;
         AppendSessionTraceLog("POLL authorization rejected; refreshed token and retrying once");
-        response = http_client_.Get(url, kUserAgent, headers);
+        response = http_client_.Get(url, kUserAgent, headers, proxy_url);
     }
     AppendSessionTraceLog("POLL response HTTP " + std::to_string(response.status_code));
     AppendSessionTraceLog("POLL response body:\n" + JsonForTrace(response.body));
@@ -898,6 +901,7 @@ void GfnClient::StopSession(AuthSession& session, const std::string& session_id)
     session = EnsureFreshSavedSession(session);
     std::string jwt_token = ResolveSessionJwt(session);
     const std::string device_id = GenerateDeviceId();
+    const std::string proxy_url = community_proxy::EnabledUrl(LoadStreamSettings());
     std::string url = session.provider.streaming_service_url + "v2/session/" + session_id;
 
     std::vector<std::string> headers = {
@@ -917,14 +921,16 @@ void GfnClient::StopSession(AuthSession& session, const std::string& session_id)
 
     AppendSessionTraceLog("STOP url=" + url);
     AppendSessionTraceLog("STOP headers:\n" + HeadersForTrace(headers));
-    HttpResponse response = http_client_.Request("DELETE", url, kUserAgent, headers);
+    HttpResponse response = http_client_.Request(
+        "DELETE", url, kUserAgent, headers, {}, proxy_url);
     if (response.status_code == 401)
     {
         session = ForceRefreshSavedSession(session);
         jwt_token = ResolveSessionJwt(session);
         headers[0] = "Authorization: GFNJWT " + jwt_token;
         AppendSessionTraceLog("STOP authorization rejected; refreshed token and retrying once");
-        response = http_client_.Request("DELETE", url, kUserAgent, headers);
+        response = http_client_.Request(
+            "DELETE", url, kUserAgent, headers, {}, proxy_url);
     }
     AppendSessionTraceLog("STOP response HTTP " + std::to_string(response.status_code));
     AppendSessionTraceLog("STOP response body:\n" + JsonForTrace(response.body));

--- a/app/src/gfn/community_proxy.cpp
+++ b/app/src/gfn/community_proxy.cpp
@@ -1,0 +1,87 @@
+#include "internal.hpp"
+
+#include "../community_proxy_policy.hpp"
+#include "../device_identity_policy.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace opennow
+{
+using namespace gfn::detail;
+
+namespace
+{
+
+std::string CommunityProxyClientId()
+{
+    const std::string path = GetAppHome() + "/community_proxy_client_id.txt";
+    const std::string stored = Trim(ReadTextFile(path));
+    if (device_identity::IsCanonicalUuid(stored))
+        return stored;
+
+    const std::string device_id = GenerateDeviceId();
+    if (device_identity::IsCanonicalUuid(device_id))
+        return device_id;
+
+    const std::string generated = GenerateUuid();
+    WriteTextFileAtomically(path, generated);
+    return generated;
+}
+
+} // namespace
+
+std::string GfnClient::ProvisionCommunityProxy() const
+{
+    JsonPtr request(json_object(), &json_decref);
+    json_object_set_new(request.get(), "clientId", json_string(CommunityProxyClientId().c_str()));
+    const std::string body = DumpJson(request.get());
+
+    const HttpResponse response = http_client_.Post(
+        std::string(community_proxy::kProvisionUrl),
+        "OpenNOW-Switch/1.0.0",
+        {"Accept: application/json", "Content-Type: application/json"},
+        body);
+
+    JsonPtr payload(nullptr, &json_decref);
+    try
+    {
+        payload = LoadJson(response.body);
+    }
+    catch (const std::exception&)
+    {
+        if (response.status_code >= 200 && response.status_code < 300)
+            throw std::runtime_error("Community proxy returned an invalid response");
+    }
+
+    if (response.status_code < 200 || response.status_code >= 300)
+    {
+        const std::string detail = payload ? GetString(payload.get(), "message") : "";
+        throw std::runtime_error(
+            detail.empty()
+                ? "Community proxy activation failed with HTTP " +
+                    std::to_string(response.status_code)
+                : detail);
+    }
+
+    std::string proxy_url = GetString(payload.get(), "proxyUrl");
+    if (proxy_url.empty())
+    {
+        const std::string username = GetString(payload.get(), "username");
+        const std::string password = GetString(payload.get(), "password");
+        if (!username.empty() && !password.empty())
+        {
+            proxy_url = "http://" + UrlEncode(username) + ":" + UrlEncode(password) + "@" +
+                std::string(community_proxy::kHost) + ":" +
+                std::string(community_proxy::kPort);
+        }
+    }
+
+    proxy_url = community_proxy::NormalizeUrl(proxy_url);
+    if (!community_proxy::IsCommunityProxyUrl(proxy_url))
+        throw std::runtime_error("Community proxy returned an invalid endpoint");
+    return proxy_url;
+}
+
+} // namespace opennow

--- a/app/src/gfn_client.hpp
+++ b/app/src/gfn_client.hpp
@@ -26,6 +26,7 @@ class GfnClient
     std::vector<PublicGame> FetchCatalogGames(
         AuthSession& session, const std::string& search_query = {}) const;
     std::vector<GameInfo> FetchLibraryGames(AuthSession& session) const;
+    std::string ProvisionCommunityProxy() const;
 
     AuthSession LoginWithQrCode(
         const LoginProvider& provider,

--- a/app/src/http_client.cpp
+++ b/app/src/http_client.cpp
@@ -26,7 +26,8 @@ HttpResponse HttpClient::Request(
     const std::string& url,
     const std::string& user_agent,
     const std::vector<std::string>& headers,
-    const std::string& body) const
+    const std::string& body,
+    const std::string& proxy_url) const
 {
     CURL* raw = curl_easy_init();
     if (!raw)
@@ -53,6 +54,12 @@ HttpResponse HttpClient::Request(
     curl_easy_setopt(curl.get(), CURLOPT_ACCEPT_ENCODING, "");
     curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 1L);
     curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 2L);
+
+    if (!proxy_url.empty())
+    {
+        curl_easy_setopt(curl.get(), CURLOPT_PROXY, proxy_url.c_str());
+        curl_easy_setopt(curl.get(), CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+    }
 
     if (header_list)
         curl_easy_setopt(curl.get(), CURLOPT_HTTPHEADER, header_list.get());
@@ -92,18 +99,20 @@ HttpResponse HttpClient::Request(
 HttpResponse HttpClient::Get(
     const std::string& url,
     const std::string& user_agent,
-    const std::vector<std::string>& headers) const
+    const std::vector<std::string>& headers,
+    const std::string& proxy_url) const
 {
-    return Request("GET", url, user_agent, headers);
+    return Request("GET", url, user_agent, headers, {}, proxy_url);
 }
 
 HttpResponse HttpClient::Post(
     const std::string& url,
     const std::string& user_agent,
     const std::vector<std::string>& headers,
-    const std::string& body) const
+    const std::string& body,
+    const std::string& proxy_url) const
 {
-    return Request("POST", url, user_agent, headers, body);
+    return Request("POST", url, user_agent, headers, body, proxy_url);
 }
 
 } // namespace opennow

--- a/app/src/http_client.hpp
+++ b/app/src/http_client.hpp
@@ -20,18 +20,21 @@ class HttpClient
         const std::string& url,
         const std::string& user_agent,
         const std::vector<std::string>& headers = {},
-        const std::string& body = {}) const;
+        const std::string& body = {},
+        const std::string& proxy_url = {}) const;
 
     HttpResponse Get(
         const std::string& url,
         const std::string& user_agent,
-        const std::vector<std::string>& headers = {}) const;
+        const std::vector<std::string>& headers = {},
+        const std::string& proxy_url = {}) const;
 
     HttpResponse Post(
         const std::string& url,
         const std::string& user_agent,
         const std::vector<std::string>& headers,
-        const std::string& body) const;
+        const std::string& body,
+        const std::string& proxy_url = {}) const;
 };
 
 } // namespace opennow

--- a/app/src/settings_tab.cpp
+++ b/app/src/settings_tab.cpp
@@ -9,6 +9,7 @@
 #include "stream_settings_policy.hpp"
 #include "stream_diagnostics.hpp"
 #include "subscription_display.hpp"
+#include "ui_action_guard.hpp"
 #include "ui_helpers.hpp"
 
 #include <cstdint>
@@ -129,7 +130,9 @@ bool SameSettings(const StreamSettings& left, const StreamSettings& right)
            left.persist_game_settings == right.persist_game_settings &&
            left.controller_layout == right.controller_layout &&
            left.image_quality_mode == right.image_quality_mode &&
-           left.interface_language == right.interface_language;
+           left.interface_language == right.interface_language &&
+           left.community_proxy_enabled == right.community_proxy_enabled &&
+           left.community_proxy_url == right.community_proxy_url;
 }
 
 } // namespace
@@ -428,6 +431,12 @@ void SettingsTab::RebuildCategory()
     if (!content_container_)
         return;
 
+    const size_t selected = static_cast<size_t>(category_);
+    brls::View* stable_focus = selected < category_nav_items_.size()
+        ? category_nav_items_[selected].row
+        : static_cast<brls::View*>(this);
+    MoveFocusBeforeDestroy(content_container_, stable_focus);
+
     option_values_.clear();
     content_container_->clearViews();
     switch (category_)
@@ -524,6 +533,22 @@ void SettingsTab::BuildStreamPage()
     AddInfoLine(quality, "Decoder", "Automatic hardware decode with fallback");
     AddInfoLine(quality, "Server", "Automatic selection for best latency");
     content_container_->addView(quality);
+
+    auto* connection = MakeSection(
+        "Connection",
+        "Optional routing for NVIDIA catalog, session creation and queue requests.");
+    connection->addView(MakeOptionRow(
+        "Zortos community proxy",
+        "Streaming, signaling and account authentication always stay direct.",
+        [this] {
+            if (community_proxy_provisioning_)
+                return std::string("Connecting...");
+            return draft_settings_.community_proxy_enabled
+                ? std::string("Enabled")
+                : std::string("Disabled");
+        },
+        [this](brls::View* view) { return ToggleCommunityProxy(view); }));
+    content_container_->addView(connection);
 }
 
 void SettingsTab::BuildPreferencesPage()
@@ -611,6 +636,8 @@ bool SettingsTab::SaveChanges(brls::View* view)
         return true;
     }
 
+    const bool interface_language_changed =
+        draft_settings_.interface_language != saved_settings_.interface_language;
     if (!SaveStreamSettings(draft_settings_))
     {
         ShowError("Settings Save Failed", "Could not safely write stream_settings.json to the SD card.");
@@ -628,7 +655,8 @@ bool SettingsTab::SaveChanges(brls::View* view)
         "Account", "Stream", "Preferences", "App"};
     for (size_t index = 0; index < category_nav_items_.size() && index < category_names.size(); ++index)
         category_nav_items_[index].label->setText(Tr(category_names[index]));
-    SelectCategory(category_);
+    if (interface_language_changed)
+        SelectCategory(category_);
     brls::Application::notify(Tr("Settings saved; changes apply to the next stream"));
     return true;
 }
@@ -829,6 +857,8 @@ bool SettingsTab::CycleStreamPreset(brls::View* view)
     const std::string controller_layout = draft_settings_.controller_layout;
     const std::string image_quality_mode = draft_settings_.image_quality_mode;
     const std::string interface_language = draft_settings_.interface_language;
+    const bool community_proxy_enabled = draft_settings_.community_proxy_enabled;
+    const std::string community_proxy_url = draft_settings_.community_proxy_url;
 
     draft_settings_ = NextStreamPreset(draft_settings_);
     draft_settings_.audio_enabled = audio_enabled;
@@ -841,7 +871,62 @@ bool SettingsTab::CycleStreamPreset(brls::View* view)
     draft_settings_.controller_layout = controller_layout;
     draft_settings_.image_quality_mode = image_quality_mode;
     draft_settings_.interface_language = interface_language;
+    draft_settings_.community_proxy_enabled = community_proxy_enabled;
+    draft_settings_.community_proxy_url = community_proxy_url;
     MarkDirty();
+    return true;
+}
+
+bool SettingsTab::ToggleCommunityProxy(brls::View* view)
+{
+    (void)view;
+    if (community_proxy_provisioning_)
+        return true;
+
+    if (draft_settings_.community_proxy_enabled)
+    {
+        draft_settings_.community_proxy_enabled = false;
+        MarkDirty();
+        return true;
+    }
+
+    auto* dialog = new brls::Dialog(
+        "The Zortos community proxy is optional, shared and may be rate-limited or "
+        "unavailable. It only routes NVIDIA catalog and session requests; streaming "
+        "traffic stays direct.");
+    dialog->addButton("Enable proxy", [this]() {
+        community_proxy_provisioning_ = true;
+        UpdateOptionValues();
+        brls::Application::notify("Activating community proxy...");
+
+        GfnClient client = client_;
+        brls::async([this, client]() mutable {
+            try
+            {
+                std::string proxy_url = client.ProvisionCommunityProxy();
+                brls::sync([this, proxy_url = std::move(proxy_url)]() mutable {
+                    draft_settings_.community_proxy_url = std::move(proxy_url);
+                    draft_settings_.community_proxy_enabled = true;
+                    community_proxy_provisioning_ = false;
+                    MarkDirty();
+                    UpdateOptionValues();
+                    brls::Application::notify(
+                        "Community proxy ready; press X to save");
+                });
+            }
+            catch (const std::exception& ex)
+            {
+                const std::string message = ex.what();
+                brls::sync([this, message] {
+                    community_proxy_provisioning_ = false;
+                    UpdateOptionValues();
+                    ShowError("Community Proxy Failed", message);
+                });
+            }
+        }, false);
+    });
+    dialog->addButton("Cancel", [] {});
+    dialog->open();
     return true;
 }
 

--- a/app/src/settings_tab.hpp
+++ b/app/src/settings_tab.hpp
@@ -64,6 +64,7 @@ class SettingsTab : public brls::Box
     bool BeginLogin(brls::View* view);
     bool ClearCoverCache(brls::View* view);
     bool CycleStreamPreset(brls::View* view);
+    bool ToggleCommunityProxy(brls::View* view);
     bool ChooseGameLanguage(brls::View* view);
     bool TogglePersistGameSettings(brls::View* view);
     bool ToggleControllerLayout(brls::View* view);
@@ -91,6 +92,7 @@ class SettingsTab : public brls::Box
     StreamSettings draft_settings_;
     bool settings_loaded_ = false;
     bool dirty_ = false;
+    bool community_proxy_provisioning_ = false;
 };
 
 } // namespace opennow

--- a/app/src/stream_settings.cpp
+++ b/app/src/stream_settings.cpp
@@ -1,6 +1,7 @@
 #include "stream_settings.hpp"
 #include "app_paths.hpp"
 #include "atomic_file_replace.hpp"
+#include "community_proxy_policy.hpp"
 #include "localization.hpp"
 
 #include <jansson.h>
@@ -121,6 +122,15 @@ StreamSettings Sanitize(StreamSettings settings)
     if (!IsSupportedInterfaceLanguage(settings.interface_language))
         settings.interface_language = "en";
 
+    if (!settings.community_proxy_url.empty() &&
+        !community_proxy::IsCommunityProxyUrl(settings.community_proxy_url))
+    {
+        settings.community_proxy_enabled = false;
+        settings.community_proxy_url.clear();
+    }
+    if (settings.community_proxy_enabled && settings.community_proxy_url.empty())
+        settings.community_proxy_enabled = false;
+
     return settings;
 }
 
@@ -128,10 +138,21 @@ StreamSettings Sanitize(StreamSettings settings)
 
 const std::vector<StreamSettings>& StreamPresets()
 {
+    const auto make_preset = [](
+        const char* id, const char* label, int width, int height, int fps, int bitrate_kbps) {
+        StreamSettings preset;
+        preset.preset_id = id;
+        preset.label = label;
+        preset.width = width;
+        preset.height = height;
+        preset.fps = fps;
+        preset.bitrate_kbps = bitrate_kbps;
+        return preset;
+    };
     static const std::vector<StreamSettings> presets = {
-        {"safe", "Safe", 1280, 720, 30, 8000, "H264", "Auto"},
-        {"balanced", "Balanced", 1280, 720, 60, 12000, "H264", "Auto"},
-        {"quality", "Quality", 1920, 1080, 60, 20000, "H264", "Auto"},
+        make_preset("safe", "Safe", 1280, 720, 30, 8000),
+        make_preset("balanced", "Balanced", 1280, 720, 60, 12000),
+        make_preset("quality", "Quality", 1920, 1080, 60, 20000),
     };
     return presets;
 }
@@ -227,6 +248,10 @@ StreamSettings LoadStreamSettings()
         root.get(), "image_quality_mode", settings.image_quality_mode);
     settings.interface_language = JsonField(
         root.get(), "interface_language", settings.interface_language);
+    settings.community_proxy_enabled = JsonBool(
+        root.get(), "community_proxy_enabled", settings.community_proxy_enabled);
+    settings.community_proxy_url = JsonField(
+        root.get(), "community_proxy_url", settings.community_proxy_url);
     return Sanitize(settings);
 }
 
@@ -259,6 +284,10 @@ bool SaveStreamSettings(const StreamSettings& settings)
         root.get(), "image_quality_mode", json_string(clean.image_quality_mode.c_str()));
     json_object_set_new(
         root.get(), "interface_language", json_string(clean.interface_language.c_str()));
+    json_object_set_new(
+        root.get(), "community_proxy_enabled", json_boolean(clean.community_proxy_enabled));
+    json_object_set_new(
+        root.get(), "community_proxy_url", json_string(clean.community_proxy_url.c_str()));
 
     char* dump = json_dumps(root.get(), JSON_INDENT(2));
     if (!dump)
@@ -311,7 +340,9 @@ std::string FormatStreamSettings(const StreamSettings& settings)
            " | Save game graphics: " +
            (settings.persist_game_settings ? "On" : "Off") +
            " | Controls: " + settings.controller_layout +
-           " | Motion quality: " + settings.image_quality_mode;
+           " | Motion quality: " + settings.image_quality_mode +
+           " | Community proxy: " +
+           (settings.community_proxy_enabled ? "On" : "Off");
            
 }
 

--- a/app/src/stream_settings.hpp
+++ b/app/src/stream_settings.hpp
@@ -26,6 +26,8 @@ struct StreamSettings
     std::string controller_layout = "Xbox";
     std::string image_quality_mode = "Adaptive";
     std::string interface_language = "en";
+    bool community_proxy_enabled = false;
+    std::string community_proxy_url;
 };
 
 struct GameLanguageOption

--- a/tests/community_proxy_policy_test.cpp
+++ b/tests/community_proxy_policy_test.cpp
@@ -1,0 +1,39 @@
+#include "community_proxy_policy.hpp"
+
+#include <cassert>
+#include <string>
+
+int main()
+{
+    using opennow::community_proxy::EnabledUrl;
+    using opennow::community_proxy::IsCommunityProxyUrl;
+
+    const std::string primary =
+        "http://client:secret@opennow-proxy-tcp.zortos.me:3128";
+    const std::string fallback =
+        "http://client:secret@217.76.50.166:3128";
+
+    assert(IsCommunityProxyUrl(primary));
+    assert(IsCommunityProxyUrl(
+        "client:secret@opennow-proxy-tcp.zortos.me:3128"));
+    assert(IsCommunityProxyUrl("  " + fallback + "  "));
+    assert(IsCommunityProxyUrl(primary + "/"));
+    assert(!IsCommunityProxyUrl("https://client:secret@opennow-proxy-tcp.zortos.me:3128"));
+    assert(!IsCommunityProxyUrl("http://opennow-proxy-tcp.zortos.me:3128"));
+    assert(!IsCommunityProxyUrl("http://client:secret@opennow-proxy-tcp.zortos.me:8080"));
+    assert(!IsCommunityProxyUrl("http://client:secret@proxy.example.com:3128"));
+    assert(!IsCommunityProxyUrl(primary + "/unexpected"));
+    assert(!IsCommunityProxyUrl(primary + "?redirect=example.com"));
+
+    opennow::StreamSettings settings;
+    settings.community_proxy_url = primary;
+    assert(EnabledUrl(settings).empty());
+    settings.community_proxy_enabled = true;
+    assert(EnabledUrl(settings) == primary);
+    settings.community_proxy_url =
+        "client:secret@opennow-proxy-tcp.zortos.me:3128";
+    assert(EnabledUrl(settings) == primary);
+    settings.community_proxy_url = "http://client:secret@proxy.example.com:3128";
+    assert(EnabledUrl(settings).empty());
+    return 0;
+}

--- a/tests/device_identity_policy_test.cpp
+++ b/tests/device_identity_policy_test.cpp
@@ -7,9 +7,19 @@ static_assert(!opennow::device_identity::IsUsableStoredDeviceId(
     "12345678-1234-5678-1234-567812345678"));
 static_assert(opennow::device_identity::IsUsableStoredDeviceId(
     "2b14829e-1bd6-49b9-8e92-cf25d03492c4"));
+static_assert(opennow::device_identity::IsCanonicalUuid(
+    "2b14829e-1bd6-49b9-8e92-cf25d03492c4"));
+static_assert(opennow::device_identity::IsCanonicalUuid(
+    "2B14829E-1BD6-49B9-8E92-CF25D03492C4"));
+static_assert(!opennow::device_identity::IsCanonicalUuid("legacy-unique-id"));
+static_assert(!opennow::device_identity::IsCanonicalUuid(
+    "2b14829e1bd6-49b9-8e92-cf25d03492c4"));
+static_assert(!opennow::device_identity::IsCanonicalUuid(
+    "2b14829e-1bd6-49b9-8e92-cf25d03492cz"));
 
 int main()
 {
     assert(opennow::device_identity::IsUsableStoredDeviceId("legacy-unique-id"));
+    assert(!opennow::device_identity::IsCanonicalUuid("legacy-unique-id"));
     return 0;
 }

--- a/tests/stream_settings_policy_test.cpp
+++ b/tests/stream_settings_policy_test.cpp
@@ -11,6 +11,9 @@ int main()
     value.persist_game_settings = false;
     value.controller_layout = "Switch";
     value.image_quality_mode = "Adaptive";
+    value.community_proxy_enabled = true;
+    value.community_proxy_url =
+        "http://client:secret@opennow-proxy-tcp.zortos.me:3128";
 
     opennow::settings::CycleResolution(value);
     assert(value.width == 1920 && value.height == 1080);
@@ -19,6 +22,8 @@ int main()
     assert(value.game_language == "ru_RU" && !value.persist_game_settings);
     assert(value.controller_layout == "Switch");
     assert(value.image_quality_mode == "Adaptive");
+    assert(value.community_proxy_enabled);
+    assert(!value.community_proxy_url.empty());
 
     opennow::settings::CycleResolution(value);
     assert(value.width == 1280 && value.height == 720);


### PR DESCRIPTION
## Summary

- add an opt-in Zortos community proxy toggle under Stream settings
- provision authenticated proxy credentials in the background and persist them atomically
- proxy only NVIDIA catalog, CloudMatch session creation, queue polling, and session cleanup requests
- keep authentication, WebRTC signaling, and media traffic direct
- validate provisioned endpoints against the supported community proxy hosts
- use a dedicated persistent UUID when a console still has a legacy non-UUID device ID
- prevent the Settings save flow from leaving a stale focused “ghost” button

## Why

The Switch client needs the same optional community-proxy path as desktop OpenNOW for users who cannot reliably reach the NVIDIA catalog or CloudMatch endpoints directly.

Two Switch-specific recovery cases are included:

- Existing installations may have a legacy device ID that is not a UUID, while the provisioning API requires a UUID. The proxy now receives a separate stable UUID without changing the ID used to encrypt saved accounts.
- Rebuilding Settings content while an option was focused could leave Borealis pointing at a freed view. Ordinary saves no longer rebuild the page, and unavoidable rebuilds move focus to the stable sidebar first.

## User impact

Users can enable or disable the community proxy from Settings. Streaming latency and signaling remain unaffected because only catalog and session-management HTTP calls use the proxy. Saving settings no longer leaves a crash-prone ghost control.

## Validation

- `g++ -std=c++20 -Wall -Wextra -Werror -Iapp/src tests/community_proxy_policy_test.cpp`
- `g++ -std=c++20 -Wall -Wextra -Werror -Iapp/src tests/device_identity_policy_test.cpp`
- `g++ -std=c++20 -Wall -Wextra -Werror -Iapp/src tests/stream_settings_policy_test.cpp`
- full Switch build: `ninja -C build/switch SwitchNOW.nro -j8`
- iterative hardware deployment via `nxlink`
