### PR TITLE
Separate video settings and add server location selection

### DIFF
--- a/app/src/StreamView.cpp
+++ b/app/src/StreamView.cpp
@@ -144,6 +144,7 @@ StreamView::StreamView(
     , game_title_(game_title) {
     const auto stream_settings = opennow::LoadStreamSettings();
     debug_diagnostics_ = stream_settings.debug_diagnostics;
+    stats_overlay_enabled_ = stream_settings.stats_overlay_enabled;
     controller_layout_ = stream_settings.controller_layout;
     opennow::SetStreamDiagnosticsEnabled(debug_diagnostics_);
     free_tier_session_ = auth_.user.membership_tier_verified &&
@@ -774,35 +775,53 @@ void StreamView::UpdatePerformanceCounter(const VideoPerformanceCounters& counte
         now - fps_window_started_);
     if (elapsed >= std::chrono::milliseconds(750)) {
         const float scale = elapsed.count() > 0 ? 1000.0f / static_cast<float>(elapsed.count()) : 0.0f;
-        incoming_fps_ = static_cast<float>(counters.access_units - previous_video_counters_.access_units) * scale;
-        decoded_fps_ = static_cast<float>(counters.decoded_frames - previous_video_counters_.decoded_frames) * scale;
-        presented_fps_ = static_cast<float>(counters.presented_frames - previous_video_counters_.presented_frames) * scale;
+        const auto delta = [](uint64_t current, uint64_t previous) {
+            return current >= previous ? current - previous : uint64_t {0};
+        };
+        incoming_fps_ = static_cast<float>(
+            delta(counters.access_units, previous_video_counters_.access_units)) * scale;
+        decoded_fps_ = static_cast<float>(
+            delta(counters.decoded_frames, previous_video_counters_.decoded_frames)) * scale;
+        presented_fps_ = static_cast<float>(
+            delta(counters.presented_frames, previous_video_counters_.presented_frames)) * scale;
+        stream_bitrate_mbps_ = static_cast<float>(
+            delta(counters.access_unit_bytes, previous_video_counters_.access_unit_bytes)) *
+            scale * 8.0f / 1000000.0f;
+        network_rtt_ms_ = session_ ? session_->get_network_rtt_ms() : -1;
         previous_video_counters_ = counters;
         fps_window_started_ = now;
     }
 }
 
 void StreamView::DrawPerformanceOverlay(NVGcontext* vg, float x, float y) {
-    char text[80];
-    std::snprintf(text, sizeof(text), "IN %.0f  DEC %.0f  OUT %.0f", incoming_fps_, decoded_fps_, presented_fps_);
+    char text[128];
+    if (network_rtt_ms_ >= 0) {
+        std::snprintf(
+            text, sizeof(text), "FPS  %.0f     BITRATE  %.1f Mbps     PING  %d ms",
+            presented_fps_, stream_bitrate_mbps_, network_rtt_ms_);
+    } else {
+        std::snprintf(
+            text, sizeof(text), "FPS  %.0f     BITRATE  %.1f Mbps     PING  -- ms",
+            presented_fps_, stream_bitrate_mbps_);
+    }
 
     const float box_x = x + 16.0f;
     const float box_y = y + 16.0f;
     nvgBeginPath(vg);
-    nvgRoundedRect(vg, box_x, box_y, 310.0f, 42.0f, 8.0f);
+    nvgRoundedRect(vg, box_x, box_y, 520.0f, 46.0f, 8.0f);
     nvgFillColor(vg, nvgRGBA(8, 12, 14, 205));
     nvgFill(vg);
 
     nvgBeginPath(vg);
-    nvgRoundedRect(vg, box_x + 6.0f, box_y + 7.0f, 4.0f, 28.0f, 2.0f);
+    nvgRoundedRect(vg, box_x + 6.0f, box_y + 7.0f, 4.0f, 32.0f, 2.0f);
     nvgFillColor(vg, nvgRGB(55, 220, 125));
     nvgFill(vg);
 
-    nvgFontSize(vg, 24.0f);
+    nvgFontSize(vg, 18.0f);
     nvgFontFaceId(vg, brls::Application::getFont(brls::FONT_REGULAR));
     nvgFillColor(vg, nvgRGB(245, 250, 247));
     nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-    nvgText(vg, box_x + 18.0f, box_y + 21.0f, text, nullptr);
+    nvgText(vg, box_x + 20.0f, box_y + 23.0f, text, nullptr);
 }
 
 void StreamView::DrawNteAutoLoginStatus(
@@ -1327,7 +1346,7 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
     }
 
     const auto notice_now = std::chrono::steady_clock::now();
-    if (debug_diagnostics_ &&
+    if ((debug_diagnostics_ || stats_overlay_enabled_) &&
         stream_end_reason_ == opennow::StreamEndReason::None)
         DrawPerformanceOverlay(vg, x, y);
     if (stream_end_reason_ == opennow::StreamEndReason::None)

--- a/app/src/StreamView.hpp
+++ b/app/src/StreamView.hpp
@@ -103,6 +103,7 @@ private:
     std::string game_title_;
     bool cloud_stop_requested_ = false;
     bool debug_diagnostics_ = false;
+    bool stats_overlay_enabled_ = false;
     std::string controller_layout_ = "Xbox";
     bool show_debug_overlay_ = false;
     bool is_nte_session_ = false;
@@ -143,6 +144,8 @@ private:
     float incoming_fps_ = 0.0f;
     float decoded_fps_ = 0.0f;
     float presented_fps_ = 0.0f;
+    float stream_bitrate_mbps_ = 0.0f;
+    int network_rtt_ms_ = -1;
     bool gamepad_state_initialized_ = false;
     uint16_t last_gamepad_buttons_ = 0;
     uint8_t last_left_trigger_ = 0;

--- a/app/src/gfn/authentication.cpp
+++ b/app/src/gfn/authentication.cpp
@@ -2,6 +2,8 @@
 #include "persistence_internal.hpp"
 
 #include "../auth_policy.hpp"
+#include "../server_location_policy.hpp"
+#include "../stream_settings.hpp"
 
 #include <algorithm>
 #include <array>
@@ -484,8 +486,12 @@ std::string FetchVpcId(const HttpClient& http_client, const AuthSession& session
     if (token.empty())
         return "NP-AMS-08";
 
-    const std::string url = EnsureTrailingSlash(session.provider.streaming_service_url) +
-        "v2/serverInfo";
+    const StreamSettings settings = LoadStreamSettings();
+    const std::string base_url = server_location::ResolveStreamingBaseUrl(
+        settings.region, session.provider.streaming_service_url);
+    if (base_url.empty())
+        return "NP-AMS-08";
+    const std::string url = base_url + "v2/serverInfo";
     std::vector<std::string> headers = BuildMembershipHeaders(token);
     for (std::string& header : headers)
     {

--- a/app/src/gfn/catalog.cpp
+++ b/app/src/gfn/catalog.cpp
@@ -2,6 +2,7 @@
 
 #include "../community_proxy_policy.hpp"
 #include "../play_history.hpp"
+#include "../server_location_policy.hpp"
 #include "../stream_settings.hpp"
 
 #include <algorithm>
@@ -272,8 +273,14 @@ std::string ResolveVpcId(
     const AuthSession& session,
     const std::string& proxy_url)
 {
+    const StreamSettings settings = LoadStreamSettings();
+    const std::string streaming_base_url = server_location::ResolveStreamingBaseUrl(
+        settings.region, session.provider.streaming_service_url);
+    if (streaming_base_url.empty())
+        return "GFN-PC";
+
     const HttpResponse response = http_client.Get(
-        EnsureTrailingSlash(session.provider.streaming_service_url) + "v2/serverInfo",
+        streaming_base_url + "v2/serverInfo",
         GfnClient::kUserAgent,
         BuildGfnLcarsHeaders(ResolveSessionJwt(session), "NATIVE", "NVIDIA-CLASSIC", true),
         proxy_url);

--- a/app/src/gfn/cloud_session.cpp
+++ b/app/src/gfn/cloud_session.cpp
@@ -1,6 +1,7 @@
 #include "internal.hpp"
 
 #include "../community_proxy_policy.hpp"
+#include "../server_location_policy.hpp"
 #include "../stream_diagnostics.hpp"
 #include "../stream_settings.hpp"
 
@@ -451,7 +452,8 @@ std::string GetActiveCloudSessionPath()
 void RememberActiveCloudSession(
     const AuthSession& auth,
     const std::string& session_id,
-    const std::string& launch_app_id)
+    const std::string& launch_app_id,
+    const std::string& streaming_base_url)
 {
     if (session_id.empty())
         return;
@@ -462,6 +464,8 @@ void RememberActiveCloudSession(
         json_object_set_new(root.get(), "session_id", json_string(session_id.c_str()));
         json_object_set_new(root.get(), "user_id", json_string(auth.user.user_id.c_str()));
         json_object_set_new(root.get(), "launch_app_id", json_string(launch_app_id.c_str()));
+        json_object_set_new(
+            root.get(), "streaming_base_url", json_string(streaming_base_url.c_str()));
         json_object_set_new(root.get(), "created_at_ms", json_integer(NowMs()));
         WriteJsonToFile(GetActiveCloudSessionPath(), root.get());
     }
@@ -469,6 +473,39 @@ void RememberActiveCloudSession(
     {
         AppendAuthLog("session: unable to persist active session error=" + std::string(e.what()));
     }
+}
+
+std::string LoadActiveCloudSessionStreamingBaseUrl(
+    const AuthSession& auth,
+    const std::string& session_id)
+{
+    const std::string body = ReadTextFile(GetActiveCloudSessionPath());
+    if (body.empty())
+        return {};
+
+    try
+    {
+        JsonPtr root = LoadJson(body);
+        if (GetString(root.get(), "user_id") != auth.user.user_id ||
+            GetString(root.get(), "session_id") != session_id)
+            return {};
+        return server_location::NormalizeStreamingBaseUrl(
+            GetString(root.get(), "streaming_base_url"));
+    }
+    catch (...)
+    {
+        return {};
+    }
+}
+
+std::string ResolveConfiguredStreamingBaseUrl(const AuthSession& session)
+{
+    const StreamSettings settings = LoadStreamSettings();
+    const std::string base_url = server_location::ResolveStreamingBaseUrl(
+        settings.region, session.provider.streaming_service_url);
+    if (base_url.empty())
+        throw std::runtime_error("The selected GeForce NOW server location is invalid.");
+    return base_url;
 }
 
 std::string LoadActiveCloudSessionId(const AuthSession& auth)
@@ -664,7 +701,11 @@ SessionInfo GfnClient::StartSession(AuthSession& session, const std::string& lau
 
     const StreamSettings stream_settings = LoadStreamSettings();
     const std::string proxy_url = community_proxy::EnabledUrl(stream_settings);
-    std::string url = session.provider.streaming_service_url +
+    const std::string streaming_base_url = server_location::ResolveStreamingBaseUrl(
+        stream_settings.region, session.provider.streaming_service_url);
+    if (streaming_base_url.empty())
+        throw std::runtime_error("The selected GeForce NOW server location is invalid.");
+    std::string url = streaming_base_url +
         "v2/session?keyboardLayout=en-US_qwerty&languageCode=" +
         stream_settings.game_language;
 
@@ -782,7 +823,8 @@ SessionInfo GfnClient::StartSession(AuthSession& session, const std::string& lau
 
     if (app_patching)
         AppendSessionTraceLog("START pending reason=app_patching; polling created session");
-    RememberActiveCloudSession(session, info.session_id, launch_app_id);
+    RememberActiveCloudSession(
+        session, info.session_id, launch_app_id, streaming_base_url);
     AppendSessionTraceLog("START parsed: " + SessionInfoTraceSummary(info));
     return info;
 }
@@ -793,7 +835,11 @@ SessionInfo GfnClient::PollSession(AuthSession& session, const std::string& sess
     std::string jwt_token = ResolveSessionJwt(session);
     const std::string device_id = GenerateDeviceId();
     const std::string proxy_url = community_proxy::EnabledUrl(LoadStreamSettings());
-    std::string url = session.provider.streaming_service_url + "v2/session/" + session_id;
+    std::string streaming_base_url =
+        LoadActiveCloudSessionStreamingBaseUrl(session, session_id);
+    if (streaming_base_url.empty())
+        streaming_base_url = ResolveConfiguredStreamingBaseUrl(session);
+    std::string url = streaming_base_url + "v2/session/" + session_id;
 
     std::vector<std::string> headers = {
         "Authorization: GFNJWT " + jwt_token,
@@ -902,7 +948,11 @@ void GfnClient::StopSession(AuthSession& session, const std::string& session_id)
     std::string jwt_token = ResolveSessionJwt(session);
     const std::string device_id = GenerateDeviceId();
     const std::string proxy_url = community_proxy::EnabledUrl(LoadStreamSettings());
-    std::string url = session.provider.streaming_service_url + "v2/session/" + session_id;
+    std::string streaming_base_url =
+        LoadActiveCloudSessionStreamingBaseUrl(session, session_id);
+    if (streaming_base_url.empty())
+        streaming_base_url = ResolveConfiguredStreamingBaseUrl(session);
+    std::string url = streaming_base_url + "v2/session/" + session_id;
 
     std::vector<std::string> headers = {
         "Authorization: GFNJWT " + jwt_token,

--- a/app/src/gfn/regions.cpp
+++ b/app/src/gfn/regions.cpp
@@ -1,0 +1,146 @@
+#include "internal.hpp"
+
+#include "../server_location_policy.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace opennow
+{
+using namespace gfn::detail;
+
+namespace
+{
+constexpr const char* kLcarsClientId = "ec7e38d4-03af-4b58-b131-cfb0495903ab";
+constexpr const char* kClientVersion = "2.0.80.173";
+
+std::vector<std::string> BuildRegionHeaders(const std::string& token)
+{
+    std::vector<std::string> headers = {
+        "Accept: application/json",
+        "nv-client-id: " + std::string(kLcarsClientId),
+        "nv-client-type: BROWSER",
+        "nv-client-version: " + std::string(kClientVersion),
+        "nv-client-streamer: WEBRTC",
+        "nv-device-os: WINDOWS",
+        "nv-device-type: DESKTOP",
+        "User-Agent: " + std::string(GfnClient::kUserAgent),
+    };
+    if (!token.empty())
+        headers.push_back("Authorization: GFNJWT " + token);
+    return headers;
+}
+
+int MeasureAverageLatency(const HttpClient& http_client, const std::string& url)
+{
+    // Match the desktop app: one warm-up connect, then average three measured
+    // TCP connects. The requests are direct so a selected HTTP proxy cannot
+    // disguise the latency between the console and a streaming location.
+    (void)http_client.MeasureConnectLatencyMs(url);
+
+    int total_ms = 0;
+    int successful = 0;
+    for (int attempt = 0; attempt < 3; ++attempt)
+    {
+        if (attempt > 0)
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        const int ping_ms = http_client.MeasureConnectLatencyMs(url);
+        if (ping_ms >= 0)
+        {
+            total_ms += ping_ms;
+            ++successful;
+        }
+    }
+
+    return successful == 0
+        ? -1
+        : static_cast<int>((total_ms + successful / 2) / successful);
+}
+
+} // namespace
+
+std::vector<StreamRegion> GfnClient::FetchStreamRegions(AuthSession& session) const
+{
+    session = RecoverSavedSession(session);
+    const std::string base_url =
+        server_location::ResolveStreamingBaseUrl("Auto", session.provider.streaming_service_url);
+    if (base_url.empty())
+        throw std::runtime_error("The GeForce NOW provider has no valid streaming endpoint.");
+
+    const HttpResponse response = http_client_.Get(
+        base_url + "v2/serverInfo",
+        kUserAgent,
+        BuildRegionHeaders(ResolveSessionJwt(session)));
+    if (response.status_code != 200)
+    {
+        throw std::runtime_error(
+            "Could not load GeForce NOW server locations (HTTP " +
+            std::to_string(response.status_code) + ").");
+    }
+
+    JsonPtr root = LoadJson(response.body);
+    json_t* metadata = json_object_get(root.get(), "metaData");
+    if (!json_is_array(metadata))
+        return {};
+
+    std::vector<StreamRegion> regions;
+    std::unordered_set<std::string> seen_urls;
+    size_t index = 0;
+    json_t* entry = nullptr;
+    json_array_foreach(metadata, index, entry)
+    {
+        const std::string name = Trim(GetString(entry, "key"));
+        const std::string raw_url = Trim(GetString(entry, "value"));
+        if (name.empty() || name == "gfn-regions" || name.rfind("gfn-", 0) == 0)
+            continue;
+
+        const std::string url = server_location::NormalizeStreamingBaseUrl(raw_url);
+        if (url.empty() || !seen_urls.insert(url).second)
+            continue;
+
+        regions.push_back({name, url, -1});
+    }
+
+    std::sort(regions.begin(), regions.end(), [](const StreamRegion& left, const StreamRegion& right) {
+        return left.name < right.name;
+    });
+    return regions;
+}
+
+std::vector<StreamRegion> GfnClient::MeasureStreamRegionLatencies(
+    std::vector<StreamRegion> regions) const
+{
+    if (regions.empty())
+        return regions;
+
+    std::atomic<size_t> next_index {0};
+    const size_t worker_count = std::min<size_t>(4, regions.size());
+    std::vector<std::thread> workers;
+    workers.reserve(worker_count);
+    for (size_t worker = 0; worker < worker_count; ++worker)
+    {
+        workers.emplace_back([this, &regions, &next_index] {
+            for (;;)
+            {
+                const size_t index = next_index.fetch_add(1, std::memory_order_relaxed);
+                if (index >= regions.size())
+                    return;
+                regions[index].ping_ms =
+                    MeasureAverageLatency(http_client_, regions[index].url);
+            }
+        });
+    }
+
+    for (std::thread& worker : workers)
+        worker.join();
+    return regions;
+}
+
+} // namespace opennow

--- a/app/src/gfn_client.hpp
+++ b/app/src/gfn_client.hpp
@@ -26,6 +26,9 @@ class GfnClient
     std::vector<PublicGame> FetchCatalogGames(
         AuthSession& session, const std::string& search_query = {}) const;
     std::vector<GameInfo> FetchLibraryGames(AuthSession& session) const;
+    std::vector<StreamRegion> FetchStreamRegions(AuthSession& session) const;
+    std::vector<StreamRegion> MeasureStreamRegionLatencies(
+        std::vector<StreamRegion> regions) const;
     std::string ProvisionCommunityProxy() const;
 
     AuthSession LoginWithQrCode(

--- a/app/src/http_client.cpp
+++ b/app/src/http_client.cpp
@@ -2,6 +2,7 @@
 
 #include <curl/curl.h>
 
+#include <cmath>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -113,6 +114,35 @@ HttpResponse HttpClient::Post(
     const std::string& proxy_url) const
 {
     return Request("POST", url, user_agent, headers, body, proxy_url);
+}
+
+int HttpClient::MeasureConnectLatencyMs(
+    const std::string& url,
+    long timeout_ms) const noexcept
+{
+    CURL* raw = curl_easy_init();
+    if (!raw)
+        return -1;
+
+    std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curl(raw, &curl_easy_cleanup);
+    curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl.get(), CURLOPT_CONNECT_ONLY, 1L);
+    curl_easy_setopt(curl.get(), CURLOPT_CONNECTTIMEOUT_MS, timeout_ms);
+    curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT_MS, timeout_ms);
+    curl_easy_setopt(curl.get(), CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl.get(), CURLOPT_FRESH_CONNECT, 1L);
+    curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 2L);
+
+    if (curl_easy_perform(curl.get()) != CURLE_OK)
+        return -1;
+
+    double connect_seconds = 0.0;
+    if (curl_easy_getinfo(curl.get(), CURLINFO_CONNECT_TIME, &connect_seconds) != CURLE_OK ||
+        connect_seconds < 0.0)
+        return -1;
+
+    return static_cast<int>(std::lround(connect_seconds * 1000.0));
 }
 
 } // namespace opennow

--- a/app/src/http_client.hpp
+++ b/app/src/http_client.hpp
@@ -35,6 +35,10 @@ class HttpClient
         const std::vector<std::string>& headers,
         const std::string& body,
         const std::string& proxy_url = {}) const;
+
+    int MeasureConnectLatencyMs(
+        const std::string& url,
+        long timeout_ms = 3000) const noexcept;
 };
 
 } // namespace opennow

--- a/app/src/models.hpp
+++ b/app/src/models.hpp
@@ -128,6 +128,13 @@ struct IceServerInfo
     std::string credential;
 };
 
+struct StreamRegion
+{
+    std::string name;
+    std::string url;
+    int ping_ms = -1;
+};
+
 struct SessionInfo
 {
     std::string session_id;

--- a/app/src/server_location_policy.hpp
+++ b/app/src/server_location_policy.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace opennow::server_location
+{
+
+inline bool IsAutomatic(const std::string& value)
+{
+    return value.empty() || value == "Auto";
+}
+
+inline bool IsValidStreamingBaseUrl(const std::string& value)
+{
+    static constexpr const char* kHttpsPrefix = "https://";
+    if (value.rfind(kHttpsPrefix, 0) != 0 || value.size() <= 8)
+        return false;
+
+    const size_t authority_end = value.find('/', 8);
+    const std::string authority = value.substr(8, authority_end - 8);
+    if (authority.empty() || authority.find('@') != std::string::npos)
+        return false;
+
+    return std::none_of(value.begin(), value.end(), [](unsigned char ch) {
+        return std::isspace(ch) || ch < 0x20 || ch == 0x7f;
+    });
+}
+
+inline std::string NormalizeStreamingBaseUrl(std::string value)
+{
+    if (!IsValidStreamingBaseUrl(value))
+        return {};
+    if (value.back() != '/')
+        value.push_back('/');
+    return value;
+}
+
+inline std::string ResolveStreamingBaseUrl(
+    const std::string& selected_region,
+    const std::string& provider_url)
+{
+    if (!IsAutomatic(selected_region))
+    {
+        const std::string selected = NormalizeStreamingBaseUrl(selected_region);
+        if (!selected.empty())
+            return selected;
+    }
+
+    return NormalizeStreamingBaseUrl(provider_url);
+}
+
+} // namespace opennow::server_location

--- a/app/src/settings_tab.cpp
+++ b/app/src/settings_tab.cpp
@@ -5,6 +5,7 @@
 #include "localization.hpp"
 #include "membership_tier_policy.hpp"
 #include "qr_login_dialog.hpp"
+#include "server_location_policy.hpp"
 #include "stream_settings.hpp"
 #include "stream_settings_policy.hpp"
 #include "stream_diagnostics.hpp"
@@ -126,6 +127,7 @@ bool SameSettings(const StreamSettings& left, const StreamSettings& right)
            left.audio_buffer_ms == right.audio_buffer_ms &&
            left.video_backend == right.video_backend &&
            left.debug_diagnostics == right.debug_diagnostics &&
+           left.stats_overlay_enabled == right.stats_overlay_enabled &&
            left.game_language == right.game_language &&
            left.persist_game_settings == right.persist_game_settings &&
            left.controller_layout == right.controller_layout &&
@@ -514,25 +516,58 @@ void SettingsTab::BuildAccountPage()
 
 void SettingsTab::BuildStreamPage()
 {
-    auto* quality = MakeSection(
-        "Stream quality",
-        "Each profile sets resolution, frame rate and bitrate together.");
-    quality->addView(MakeOptionRow(
-        "Quality profile", "Safe favors stability; Quality favors detail.",
+    auto* location = MakeSection(
+        "Server location",
+        "Use automatic routing or choose a specific GeForce NOW data center.");
+    location->addView(MakeOptionRow(
+        "Location",
+        "Locations are ranked by direct latency from this console.",
+        [this] { return ServerLocationValue(); },
+        [this](brls::View* view) { return ChooseServerLocation(view); }));
+    location->addView(MakeActionRow(
+        "Latency test",
+        "Reload available locations and test each connection again.",
+        "Refresh",
+        [this](brls::View* view) { return RefreshServerLocations(view); }));
+    content_container_->addView(location);
+
+    auto* video = MakeSection(
+        "Video",
+        "Choose resolution, frame rate, bitrate and video processing separately.");
+    video->addView(MakeOptionRow(
+        "Resolution", "720p reduces load; 1080p improves detail.",
         [this] {
-            return draft_settings_.label + " / " +
-                std::to_string(draft_settings_.height) + "p / " +
-                std::to_string(draft_settings_.fps);
+            return std::to_string(draft_settings_.width) + " x " +
+                std::to_string(draft_settings_.height);
         },
-        [this](brls::View* view) { return CycleStreamPreset(view); }));
-    quality->addView(MakeOptionRow(
+        [this](brls::View* view) { return CycleResolution(view); }));
+    video->addView(MakeOptionRow(
+        "FPS", "60 FPS is smoother; 30 FPS is more resilient.",
+        [this] { return std::to_string(draft_settings_.fps) + " FPS"; },
+        [this](brls::View* view) { return CycleFrameRate(view); }));
+    video->addView(MakeOptionRow(
+        "Bitrate", "Higher values improve motion detail but need stronger Wi-Fi.",
+        [this] {
+            return std::to_string(draft_settings_.bitrate_kbps / 1000) + " Mbps";
+        },
+        [this](brls::View* view) { return CycleBitrate(view); }));
+    AddInfoLine(video, "Encoder", "H.264");
+    video->addView(MakeOptionRow(
+        "Decoder", "Choose automatic fallback, hardware-only or software-only decode.",
+        [this] {
+            if (draft_settings_.video_backend == "NVDEC")
+                return std::string("Hardware");
+            if (draft_settings_.video_backend == "Software")
+                return std::string("Software");
+            return std::string("Auto");
+        },
+        [this](brls::View* view) { return CycleVideoBackend(view); }));
+    video->addView(MakeOptionRow(
         "Picture processing",
         "Adaptive is recommended; Clarity sharpens motion; Original keeps the source unchanged.",
         [this] { return draft_settings_.image_quality_mode; },
         [this](brls::View* view) { return CycleImageQuality(view); }));
-    AddInfoLine(quality, "Decoder", "Automatic hardware decode with fallback");
-    AddInfoLine(quality, "Server", "Automatic selection for best latency");
-    content_container_->addView(quality);
+    content_container_->addView(video);
 
     auto* connection = MakeSection(
         "Connection",
@@ -549,6 +584,9 @@ void SettingsTab::BuildStreamPage()
         },
         [this](brls::View* view) { return ToggleCommunityProxy(view); }));
     content_container_->addView(connection);
+
+    if (!server_locations_loaded_ && !server_locations_loading_)
+        BeginServerLocationLoad(false, false);
 }
 
 void SettingsTab::BuildPreferencesPage()
@@ -597,6 +635,19 @@ void SettingsTab::BuildAppPage()
         [this] { return InterfaceLanguageLabel(draft_settings_.interface_language); },
         [this](brls::View* view) { return ChooseInterfaceLanguage(view); }));
     content_container_->addView(language);
+
+    auto* interface = MakeSection(
+        "Interface", "Choose what OpenNOW shows while you play.");
+    interface->addView(MakeOptionRow(
+        "Stream stats overlay",
+        "Show stream FPS, received bitrate and network ping during a session.",
+        [this] {
+            return draft_settings_.stats_overlay_enabled
+                ? std::string("Enabled")
+                : std::string("Disabled");
+        },
+        [this](brls::View* view) { return ToggleStatsOverlay(view); }));
+    content_container_->addView(interface);
 
     const ImageCacheInfo images = ReadImageCacheInfo();
     auto* cache = MakeSection("Storage", "Cover artwork is cached to keep the library responsive.");
@@ -844,36 +895,269 @@ bool SettingsTab::ClearCoverCache(brls::View* view)
     return true;
 }
 
-bool SettingsTab::CycleStreamPreset(brls::View* view)
+bool SettingsTab::CycleResolution(brls::View* view)
 {
     (void)view;
-    const bool audio_enabled = draft_settings_.audio_enabled;
-    const int audio_volume = draft_settings_.audio_volume;
-    const int audio_buffer_ms = draft_settings_.audio_buffer_ms;
-    const std::string backend = draft_settings_.video_backend;
-    const bool debug_diagnostics = draft_settings_.debug_diagnostics;
-    const std::string game_language = draft_settings_.game_language;
-    const bool persist_game_settings = draft_settings_.persist_game_settings;
-    const std::string controller_layout = draft_settings_.controller_layout;
-    const std::string image_quality_mode = draft_settings_.image_quality_mode;
-    const std::string interface_language = draft_settings_.interface_language;
-    const bool community_proxy_enabled = draft_settings_.community_proxy_enabled;
-    const std::string community_proxy_url = draft_settings_.community_proxy_url;
-
-    draft_settings_ = NextStreamPreset(draft_settings_);
-    draft_settings_.audio_enabled = audio_enabled;
-    draft_settings_.audio_volume = audio_volume;
-    draft_settings_.audio_buffer_ms = audio_buffer_ms;
-    draft_settings_.video_backend = backend;
-    draft_settings_.debug_diagnostics = debug_diagnostics;
-    draft_settings_.game_language = game_language;
-    draft_settings_.persist_game_settings = persist_game_settings;
-    draft_settings_.controller_layout = controller_layout;
-    draft_settings_.image_quality_mode = image_quality_mode;
-    draft_settings_.interface_language = interface_language;
-    draft_settings_.community_proxy_enabled = community_proxy_enabled;
-    draft_settings_.community_proxy_url = community_proxy_url;
+    settings::CycleResolution(draft_settings_);
     MarkDirty();
+    return true;
+}
+
+bool SettingsTab::CycleFrameRate(brls::View* view)
+{
+    (void)view;
+    settings::CycleFrameRate(draft_settings_);
+    MarkDirty();
+    return true;
+}
+
+bool SettingsTab::CycleBitrate(brls::View* view)
+{
+    (void)view;
+    settings::CycleBitrate(draft_settings_);
+    MarkDirty();
+    return true;
+}
+
+bool SettingsTab::CycleVideoBackend(brls::View* view)
+{
+    (void)view;
+    settings::CycleVideoBackend(draft_settings_);
+    MarkDirty();
+    return true;
+}
+
+std::string SettingsTab::ServerLocationValue() const
+{
+    if (server_locations_loading_)
+        return "Testing locations...";
+
+    const auto best = std::find_if(
+        server_locations_.begin(), server_locations_.end(),
+        [](const StreamRegion& region) { return region.ping_ms >= 0; });
+
+    if (server_location::IsAutomatic(draft_settings_.region))
+    {
+        if (best == server_locations_.end())
+            return "Auto (best)";
+        return "Auto · " + best->name + " · " +
+            std::to_string(best->ping_ms) + " ms";
+    }
+
+    const auto selected = std::find_if(
+        server_locations_.begin(), server_locations_.end(),
+        [this](const StreamRegion& region) {
+            return region.url == draft_settings_.region;
+        });
+    if (selected == server_locations_.end())
+        return "Selected server";
+
+    std::string value = selected->name;
+    if (selected->ping_ms >= 0)
+        value += " · " + std::to_string(selected->ping_ms) + " ms";
+    return value;
+}
+
+void SettingsTab::BeginServerLocationLoad(
+    bool open_when_ready,
+    bool notify_result)
+{
+    if (server_locations_loading_)
+    {
+        open_server_location_when_ready_ =
+            open_server_location_when_ready_ || open_when_ready;
+        if (notify_result)
+            brls::Application::notify("Server location test is already running");
+        return;
+    }
+
+    EnsureSessionLoaded();
+    auto& state = AppState::Instance();
+    if (!state.HasSession())
+    {
+        if (open_when_ready || notify_result)
+        {
+            ShowError(
+                "Server Locations Unavailable",
+                "Connect a GeForce NOW account before loading server locations.");
+        }
+        return;
+    }
+
+    server_locations_loading_ = true;
+    server_locations_error_.clear();
+    open_server_location_when_ready_ = open_when_ready;
+    UpdateOptionValues();
+
+    GfnClient client = client_;
+    AuthSession session = *state.session();
+    brls::async(
+        [this, client, session = std::move(session), notify_result]() mutable {
+            try
+            {
+                std::vector<StreamRegion> regions =
+                    client.FetchStreamRegions(session);
+                regions = client.MeasureStreamRegionLatencies(std::move(regions));
+                std::stable_sort(
+                    regions.begin(), regions.end(),
+                    [](const StreamRegion& left, const StreamRegion& right) {
+                        const bool left_ok = left.ping_ms >= 0;
+                        const bool right_ok = right.ping_ms >= 0;
+                        if (left_ok != right_ok)
+                            return left_ok;
+                        if (left_ok && left.ping_ms != right.ping_ms)
+                            return left.ping_ms < right.ping_ms;
+                        return left.name < right.name;
+                    });
+
+                brls::sync(
+                    [this, session = std::move(session),
+                     regions = std::move(regions), notify_result]() mutable {
+                        auto& current = AppState::Instance();
+                        if (current.HasSession() &&
+                            current.session()->user.user_id == session.user.user_id)
+                        {
+                            current.SetSession(std::move(session));
+                        }
+
+                        server_locations_ = std::move(regions);
+                        server_locations_loaded_ = true;
+                        server_locations_loading_ = false;
+                        if (server_locations_.empty())
+                        {
+                            server_locations_error_ =
+                                "GeForce NOW did not return any server locations.";
+                        }
+                        UpdateOptionValues();
+
+                        const bool should_open =
+                            open_server_location_when_ready_ &&
+                            category_ == Category::Stream;
+                        open_server_location_when_ready_ = false;
+                        if (should_open)
+                        {
+                            ChooseServerLocation(nullptr);
+                        }
+                        else if (notify_result)
+                        {
+                            brls::Application::notify(
+                                server_locations_.empty()
+                                    ? server_locations_error_
+                                    : "Server location latency test complete");
+                        }
+                    });
+            }
+            catch (const std::exception& ex)
+            {
+                const std::string message = ex.what();
+                brls::sync([this, message, notify_result] {
+                    const bool should_open =
+                        open_server_location_when_ready_ &&
+                        category_ == Category::Stream;
+                    server_locations_loading_ = false;
+                    server_locations_loaded_ =
+                        !server_locations_.empty() || should_open;
+                    server_locations_error_ = message;
+                    open_server_location_when_ready_ = false;
+                    UpdateOptionValues();
+                    if (should_open)
+                    {
+                        brls::Application::notify(
+                            "Latency test failed; automatic routing is still available");
+                        ChooseServerLocation(nullptr);
+                    }
+                    else if (notify_result)
+                    {
+                        ShowError("Server Location Test Failed", message);
+                    }
+                });
+            }
+        },
+        false);
+}
+
+bool SettingsTab::ChooseServerLocation(brls::View* view)
+{
+    (void)view;
+    if (server_locations_loading_)
+    {
+        open_server_location_when_ready_ = true;
+        brls::Application::notify("Testing GeForce NOW server locations...");
+        return true;
+    }
+
+    if (!server_locations_loaded_)
+    {
+        BeginServerLocationLoad(true, false);
+        return true;
+    }
+
+    const auto best = std::find_if(
+        server_locations_.begin(), server_locations_.end(),
+        [](const StreamRegion& region) { return region.ping_ms >= 0; });
+
+    std::vector<StreamRegion> options = server_locations_;
+    if (!server_location::IsAutomatic(draft_settings_.region))
+    {
+        const bool selected_available = std::any_of(
+            options.begin(), options.end(), [this](const StreamRegion& region) {
+                return region.url == draft_settings_.region;
+            });
+        if (!selected_available)
+        {
+            options.push_back(
+                {"Current server (not advertised)", draft_settings_.region, -1});
+        }
+    }
+
+    std::vector<std::string> labels;
+    labels.reserve(options.size() + 1);
+    std::string automatic = "Auto (best)";
+    if (best != server_locations_.end())
+    {
+        automatic += " — " + best->name + " · " +
+            std::to_string(best->ping_ms) + " ms";
+    }
+    labels.push_back(std::move(automatic));
+
+    int selected_index = 0;
+    for (size_t index = 0; index < options.size(); ++index)
+    {
+        const StreamRegion& region = options[index];
+        std::string label = region.name;
+        if (region.ping_ms >= 0)
+            label += " — " + std::to_string(region.ping_ms) + " ms";
+        else
+            label += " — Unavailable";
+        if (best != server_locations_.end() && region.url == best->url)
+            label += " · Best";
+        labels.push_back(std::move(label));
+
+        if (region.url == draft_settings_.region)
+            selected_index = static_cast<int>(index + 1);
+    }
+
+    auto* dropdown = new brls::Dropdown(
+        "Server location", labels,
+        [this, options = std::move(options)](int index) {
+            if (index < 0)
+                return;
+            draft_settings_.region =
+                index == 0 || static_cast<size_t>(index) > options.size()
+                ? "Auto"
+                : options[static_cast<size_t>(index - 1)].url;
+            MarkDirty();
+            UpdateOptionValues();
+        },
+        selected_index);
+    brls::Application::pushActivity(new brls::Activity(dropdown));
+    return true;
+}
+
+bool SettingsTab::RefreshServerLocations(brls::View* view)
+{
+    (void)view;
+    BeginServerLocationLoad(false, true);
     return true;
 }
 
@@ -934,6 +1218,14 @@ bool SettingsTab::CycleImageQuality(brls::View* view)
 {
     (void)view;
     settings::CycleImageQuality(draft_settings_);
+    MarkDirty();
+    return true;
+}
+
+bool SettingsTab::ToggleStatsOverlay(brls::View* view)
+{
+    (void)view;
+    draft_settings_.stats_overlay_enabled = !draft_settings_.stats_overlay_enabled;
     MarkDirty();
     return true;
 }

--- a/app/src/settings_tab.hpp
+++ b/app/src/settings_tab.hpp
@@ -43,7 +43,16 @@ class SettingsTab : public brls::Box
     void MarkDirty();
     bool SaveChanges(brls::View* view);
     bool RevertChanges(brls::View* view);
+    bool CycleResolution(brls::View* view);
+    bool CycleFrameRate(brls::View* view);
+    bool CycleBitrate(brls::View* view);
+    bool CycleVideoBackend(brls::View* view);
     bool CycleImageQuality(brls::View* view);
+    bool ToggleStatsOverlay(brls::View* view);
+    bool ChooseServerLocation(brls::View* view);
+    bool RefreshServerLocations(brls::View* view);
+    void BeginServerLocationLoad(bool open_when_ready, bool notify_result);
+    std::string ServerLocationValue() const;
 
     brls::Box* MakeSection(const std::string& title, const std::string& subtitle = {});
     brls::Box* MakeOptionRow(
@@ -63,7 +72,6 @@ class SettingsTab : public brls::Box
     bool SwitchSavedAccount(brls::View* view);
     bool BeginLogin(brls::View* view);
     bool ClearCoverCache(brls::View* view);
-    bool CycleStreamPreset(brls::View* view);
     bool ToggleCommunityProxy(brls::View* view);
     bool ChooseGameLanguage(brls::View* view);
     bool TogglePersistGameSettings(brls::View* view);
@@ -93,6 +101,11 @@ class SettingsTab : public brls::Box
     bool settings_loaded_ = false;
     bool dirty_ = false;
     bool community_proxy_provisioning_ = false;
+    std::vector<StreamRegion> server_locations_;
+    bool server_locations_loaded_ = false;
+    bool server_locations_loading_ = false;
+    bool open_server_location_when_ready_ = false;
+    std::string server_locations_error_;
 };
 
 } // namespace opennow

--- a/app/src/stream_settings.cpp
+++ b/app/src/stream_settings.cpp
@@ -3,6 +3,7 @@
 #include "atomic_file_replace.hpp"
 #include "community_proxy_policy.hpp"
 #include "localization.hpp"
+#include "server_location_policy.hpp"
 
 #include <jansson.h>
 
@@ -94,8 +95,15 @@ StreamSettings Sanitize(StreamSettings settings)
     if (settings.codec != "H264")
         settings.codec = "H264";
 
-    if (settings.region.empty())
+    if (server_location::IsAutomatic(settings.region))
         settings.region = "Auto";
+    else
+    {
+        settings.region =
+            server_location::NormalizeStreamingBaseUrl(settings.region);
+        if (settings.region.empty())
+            settings.region = "Auto";
+    }
 
     settings.audio_volume = std::max(800, std::min(1600, settings.audio_volume));
     settings.audio_buffer_ms = std::max(30, std::min(100, settings.audio_buffer_ms));
@@ -239,6 +247,8 @@ StreamSettings LoadStreamSettings()
     settings.audio_buffer_ms = JsonInt(root.get(), "audio_buffer_ms", settings.audio_buffer_ms);
     settings.video_backend = JsonField(root.get(), "video_backend", settings.video_backend);
     settings.debug_diagnostics = JsonBool(root.get(), "debug_diagnostics", false);
+    settings.stats_overlay_enabled = JsonBool(
+        root.get(), "stats_overlay_enabled", settings.stats_overlay_enabled);
     settings.game_language = JsonField(root.get(), "game_language", settings.game_language);
     settings.persist_game_settings = JsonBool(
         root.get(), "persist_game_settings", settings.persist_game_settings);
@@ -275,6 +285,8 @@ bool SaveStreamSettings(const StreamSettings& settings)
     json_object_set_new(root.get(), "audio_buffer_ms", json_integer(clean.audio_buffer_ms));
     json_object_set_new(root.get(), "video_backend", json_string(clean.video_backend.c_str()));
     json_object_set_new(root.get(), "debug_diagnostics", json_boolean(clean.debug_diagnostics));
+    json_object_set_new(
+        root.get(), "stats_overlay_enabled", json_boolean(clean.stats_overlay_enabled));
     json_object_set_new(root.get(), "game_language", json_string(clean.game_language.c_str()));
     json_object_set_new(
         root.get(), "persist_game_settings", json_boolean(clean.persist_game_settings));
@@ -341,6 +353,8 @@ std::string FormatStreamSettings(const StreamSettings& settings)
            (settings.persist_game_settings ? "On" : "Off") +
            " | Controls: " + settings.controller_layout +
            " | Motion quality: " + settings.image_quality_mode +
+           " | Stats overlay: " +
+           (settings.stats_overlay_enabled ? "On" : "Off") +
            " | Community proxy: " +
            (settings.community_proxy_enabled ? "On" : "Off");
            

--- a/app/src/stream_settings.hpp
+++ b/app/src/stream_settings.hpp
@@ -21,6 +21,7 @@ struct StreamSettings
     int audio_buffer_ms   = 40;
     std::string video_backend = "Auto";
     bool debug_diagnostics = false;
+    bool stats_overlay_enabled = false;
     std::string game_language = "en_US";
     bool persist_game_settings = true;
     std::string controller_layout = "Xbox";

--- a/app/src/stream_settings_policy.hpp
+++ b/app/src/stream_settings_policy.hpp
@@ -51,6 +51,16 @@ inline void CycleBitrate(StreamSettings& value)
     MarkCustom(value);
 }
 
+inline void CycleVideoBackend(StreamSettings& value)
+{
+    if (value.video_backend == "Auto")
+        value.video_backend = "NVDEC";
+    else if (value.video_backend == "NVDEC")
+        value.video_backend = "Software";
+    else
+        value.video_backend = "Auto";
+}
+
 inline void CycleImageQuality(StreamSettings& value)
 {
     value.image_quality_mode = video::NextQualityMode(value.image_quality_mode);

--- a/app/src/webrtc/diagnostics.cpp
+++ b/app/src/webrtc/diagnostics.cpp
@@ -332,6 +332,11 @@ VideoPerformanceCounters WebRtcSession::get_video_performance() const {
     return result;
 }
 
+int WebRtcSession::get_network_rtt_ms() const {
+    std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
+    return pc_ ? peer_connection_get_rtt_ms(pc_) : -1;
+}
+
 StreamTransportHealth WebRtcSession::get_transport_health() const {
     StreamTransportHealth health;
     health.peer_completed = peer_ever_completed_.load(std::memory_order_acquire);

--- a/app/src/webrtc_session.hpp
+++ b/app/src/webrtc_session.hpp
@@ -90,6 +90,7 @@ public:
     void on_rtp_sender_report(uint32_t ssrc, uint64_t ntp_us, uint32_t rtp_timestamp);
     int64_t video_target_rtp_timestamp() const;
     VideoPerformanceCounters get_video_performance() const;
+    int get_network_rtt_ms() const;
     StreamTransportHealth get_transport_health() const;
     std::string get_debug_info() const;
     bool is_terminal() const { return peer_terminal_.load(std::memory_order_acquire); }

--- a/extern/libpeer/src/peer_connection.c
+++ b/extern/libpeer/src/peer_connection.c
@@ -1021,6 +1021,11 @@ int peer_connection_get_ice_candidate_pair_stats(PeerConnection* pc,
     *failed = stats.failed;
   return 0;
 }
+
+int peer_connection_get_rtt_ms(PeerConnection* pc) {
+  return pc ? sctp_get_rtt_ms(&pc->sctp) : -1;
+}
+
 int peer_connection_get_video_rtp_stats(PeerConnection* pc, PeerVideoRtpStats* stats) {
   if (pc == NULL || stats == NULL)
     return -1;

--- a/extern/libpeer/src/peer_connection.h
+++ b/extern/libpeer/src/peer_connection.h
@@ -221,6 +221,8 @@ int peer_connection_get_ice_candidate_pair_stats(PeerConnection* pc,
                                                  int* succeeded,
                                                  int* failed);
 
+int peer_connection_get_rtt_ms(PeerConnection* pc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/extern/libpeer/src/sctp.c
+++ b/extern/libpeer/src/sctp.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "dtls_srtp.h"
+#include "ports.h"
 #include "sctp.h"
 #include "utils.h"
 #if CONFIG_USE_USRSCTP
@@ -213,6 +214,8 @@ int sctp_outgoing_data(Sctp* sctp, char* buf, size_t len, SctpDataPpid ppid, uin
 
     if (sctp_outgoing_data_cb(sctp, sctp->buf, SCTP_MTU, 0, 0) < 0)
       return -1;
+    sctp->last_outbound_tsn = ntohl(chunk->tsn);
+    sctp->last_outbound_sent_ms = ports_get_epoch_time();
     chunk->iube = 0x04;
     len -= payload_max;
     pos += payload_max;
@@ -232,6 +235,8 @@ int sctp_outgoing_data(Sctp* sctp, char* buf, size_t len, SctpDataPpid ppid, uin
 
     if (sctp_outgoing_data_cb(sctp, sctp->buf, padding_len, 0, 0) < 0)
       return -1;
+    sctp->last_outbound_tsn = ntohl(chunk->tsn);
+    sctp->last_outbound_sent_ms = ports_get_epoch_time();
   }
   return (int)original_len;
 #endif
@@ -439,10 +444,22 @@ void sctp_incoming_data(Sctp* sctp, char* buf, size_t len) {
         sctp_diag_log("internal_cookie_echo prepared peerTag=%08x cookieBytes=%u",
                       ntohl(sctp->verification_tag), ntohs(param->length) - 4);
       } break;
-      case SCTP_SACK:
+      case SCTP_SACK: {
+        SctpSackChunk* sack = (SctpSackChunk*)(buf + pos);
+        if (sctp->last_outbound_sent_ms != 0 &&
+            (int32_t)(ntohl(sack->cumulative_tsn_ack) -
+                      sctp->last_outbound_tsn) >= 0) {
+          const uint32_t sample_ms =
+              ports_get_epoch_time() - sctp->last_outbound_sent_ms;
+          if (sample_ms > 0 && sample_ms <= 5000) {
+            sctp->smoothed_rtt_ms = sctp->smoothed_rtt_ms == 0
+                ? sample_ms
+                : (sctp->smoothed_rtt_ms * 7 + sample_ms) / 8;
+          }
+          sctp->last_outbound_sent_ms = 0;
+        }
 #if 0
         LOGD("SCTP_SACK");
-        sack = (SctpSackChunk*)in_packet->chunks;
         LOGD("cumulative_tsn_ack %d", ntohl(sack->cumulative_tsn_ack));
         LOGD("a_rwnd %d", ntohl(sack->a_rwnd));
         LOGD("number_of_gap_ack_blocks %d", sack->number_of_gap_ack_blocks);
@@ -470,7 +487,7 @@ void sctp_incoming_data(Sctp* sctp, char* buf, size_t len) {
            ntohs(sack->number_of_dup_tsns));
         }
 #endif
-        break;
+      } break;
       case SCTP_COOKIE_ECHO: {
         LOGD("SCTP_COOKIE_ECHO");
         SctpChunkCommon* common = (SctpChunkCommon*)out_packet->chunks;
@@ -799,6 +816,29 @@ void sctp_destroy_association(Sctp* sctp) {
 
 int sctp_is_connected(Sctp* sctp) {
   return sctp->connected;
+}
+
+int sctp_get_rtt_ms(Sctp* sctp) {
+#if CONFIG_USE_USRSCTP
+  if (!sctp || !sctp->sock || !sctp->connected)
+    return -1;
+
+  struct sctp_status status;
+  socklen_t status_len = sizeof(status);
+  memset(&status, 0, sizeof(status));
+  if (usrsctp_getsockopt(
+          sctp->sock, IPPROTO_SCTP, SCTP_STATUS, &status, &status_len) < 0) {
+    return -1;
+  }
+
+  return status.sstat_primary.spinfo_srtt > 0
+      ? (int)status.sstat_primary.spinfo_srtt
+      : -1;
+#else
+  return sctp && sctp->smoothed_rtt_ms > 0
+      ? (int)sctp->smoothed_rtt_ms
+      : -1;
+#endif
 }
 
 void sctp_onmessage(Sctp* sctp, void (*onmessage)(char* msg, size_t len, void* userdata, uint16_t sid)) {

--- a/extern/libpeer/src/sctp.h
+++ b/extern/libpeer/src/sctp.h
@@ -155,6 +155,9 @@ typedef struct Sctp {
   int connected;
   uint32_t verification_tag;
   uint32_t tsn;
+  uint32_t last_outbound_tsn;
+  uint32_t last_outbound_sent_ms;
+  uint32_t smoothed_rtt_ms;
   DtlsSrtp* dtls_srtp;
   int stream_count;
   SctpStreamEntry stream_table[SCTP_MAX_STREAMS];
@@ -177,6 +180,8 @@ void sctp_usrsctp_init();
 void sctp_usrsctp_deinit();
 
 int sctp_is_connected(Sctp* sctp);
+
+int sctp_get_rtt_ms(Sctp* sctp);
 
 void sctp_incoming_data(Sctp* sctp, char* buf, size_t len);
 

--- a/tests/server_location_policy_test.cpp
+++ b/tests/server_location_policy_test.cpp
@@ -1,0 +1,36 @@
+#include "server_location_policy.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using namespace opennow::server_location;
+
+    assert(IsAutomatic(""));
+    assert(IsAutomatic("Auto"));
+    assert(!IsAutomatic("https://np-ams.example/"));
+
+    assert(IsValidStreamingBaseUrl("https://np-ams.example/"));
+    assert(IsValidStreamingBaseUrl("https://np-ams.example:443/path"));
+    assert(!IsValidStreamingBaseUrl("http://np-ams.example/"));
+    assert(!IsValidStreamingBaseUrl("https://user@np-ams.example/"));
+    assert(!IsValidStreamingBaseUrl("https://np-ams.example/\nHeader: value"));
+
+    assert(
+        NormalizeStreamingBaseUrl("https://np-ams.example") ==
+        "https://np-ams.example/");
+    assert(NormalizeStreamingBaseUrl("not a URL").empty());
+
+    assert(
+        ResolveStreamingBaseUrl("Auto", "https://prod.example") ==
+        "https://prod.example/");
+    assert(
+        ResolveStreamingBaseUrl(
+            "https://np-lon.example", "https://prod.example/") ==
+        "https://np-lon.example/");
+    assert(
+        ResolveStreamingBaseUrl(
+            "http://unsafe.example", "https://prod.example/") ==
+        "https://prod.example/");
+    return 0;
+}

--- a/tests/stream_settings_policy_test.cpp
+++ b/tests/stream_settings_policy_test.cpp
@@ -11,6 +11,7 @@ int main()
     value.persist_game_settings = false;
     value.controller_layout = "Switch";
     value.image_quality_mode = "Adaptive";
+    value.stats_overlay_enabled = true;
     value.community_proxy_enabled = true;
     value.community_proxy_url =
         "http://client:secret@opennow-proxy-tcp.zortos.me:3128";
@@ -22,6 +23,7 @@ int main()
     assert(value.game_language == "ru_RU" && !value.persist_game_settings);
     assert(value.controller_layout == "Switch");
     assert(value.image_quality_mode == "Adaptive");
+    assert(value.stats_overlay_enabled);
     assert(value.community_proxy_enabled);
     assert(!value.community_proxy_url.empty());
 
@@ -39,6 +41,13 @@ int main()
     value.bitrate_kbps = 25000;
     opennow::settings::CycleBitrate(value);
     assert(value.bitrate_kbps == 8000);
+
+    opennow::settings::CycleVideoBackend(value);
+    assert(value.video_backend == "Software");
+    opennow::settings::CycleVideoBackend(value);
+    assert(value.video_backend == "Auto");
+    opennow::settings::CycleVideoBackend(value);
+    assert(value.video_backend == "NVDEC");
 
     opennow::settings::CycleImageQuality(value);
     assert(value.image_quality_mode == "Clarity");


### PR DESCRIPTION
## Summary

- Split video configuration into independent resolution, FPS, bitrate, decoder, and picture-processing settings.
- Add automatic or manually selected GeForce NOW server locations with latency testing.
- Persist the selected streaming endpoint across session polling and stopping.
- Add optional FPS, bitrate, and network ping overlay statistics.
- Add server-location and stream-settings policy tests.

## Testing

- Not run; host and Switch build checks were not provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added server location selection with latency testing.
  - Added separate controls for resolution, frame rate, bitrate, and video decoder.
  - Added an optional streaming statistics overlay showing FPS, bitrate, and network ping.
  - Added automatic server-region discovery and improved session routing.

- **Bug Fixes**
  - Improved reliability when reconnecting to or stopping streaming sessions.
  - Hardened streaming URL validation and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->