### PR TITLE
Fix community proxy session startup

### DIFF
--- a/app/src/community_proxy_policy.hpp
+++ b/app/src/community_proxy_policy.hpp
@@ -66,11 +66,44 @@ inline bool IsCommunityProxyUrl(std::string_view raw)
            endpoint == std::string(kFallbackHost) + ":" + std::string(kPort);
 }
 
+inline std::string RuntimeUrl(std::string_view raw)
+{
+    std::string value = NormalizeUrl(raw);
+    if (!IsCommunityProxyUrl(value))
+        return {};
+
+    constexpr std::string_view scheme = "http://";
+    const size_t authority_end = value.find_first_of("/?#", scheme.size());
+    const size_t authority_size =
+        authority_end == std::string::npos ? value.size() - scheme.size()
+                                           : authority_end - scheme.size();
+    const size_t at = value.rfind('@', scheme.size() + authority_size);
+    const size_t endpoint_begin = at + 1;
+    const size_t endpoint_size = scheme.size() + authority_size - endpoint_begin;
+    std::string endpoint = value.substr(endpoint_begin, endpoint_size);
+    std::transform(endpoint.begin(), endpoint.end(), endpoint.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+
+    // The public hostname is proxied through Cloudflare, which does not expose
+    // the authenticated HTTP proxy's TCP port. Keep credentials intact while
+    // using the service's pinned direct endpoint so the console also avoids a
+    // DNS dependency when starting or polling a session.
+    if (endpoint == std::string(kHost) + ":" + std::string(kPort))
+    {
+        value.replace(
+            endpoint_begin,
+            endpoint_size,
+            std::string(kFallbackHost) + ":" + std::string(kPort));
+    }
+    return value;
+}
+
 inline std::string EnabledUrl(const StreamSettings& settings)
 {
     if (!settings.community_proxy_enabled || !IsCommunityProxyUrl(settings.community_proxy_url))
         return {};
-    return NormalizeUrl(settings.community_proxy_url);
+    return RuntimeUrl(settings.community_proxy_url);
 }
 
 } // namespace opennow::community_proxy

--- a/app/src/http_client.cpp
+++ b/app/src/http_client.cpp
@@ -59,7 +59,9 @@ HttpResponse HttpClient::Request(
     if (!proxy_url.empty())
     {
         curl_easy_setopt(curl.get(), CURLOPT_PROXY, proxy_url.c_str());
+        curl_easy_setopt(curl.get(), CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
         curl_easy_setopt(curl.get(), CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+        curl_easy_setopt(curl.get(), CURLOPT_NOPROXY, "");
     }
 
     if (header_list)
@@ -85,7 +87,9 @@ HttpResponse HttpClient::Request(
     if (result != CURLE_OK)
     {
         throw std::runtime_error(
-            "HTTP " + method + " failed for " + url + ": " + curl_easy_strerror(result));
+            "HTTP " + method + " failed for " + url +
+            (proxy_url.empty() ? std::string() : " while using the configured proxy") +
+            ": " + curl_easy_strerror(result));
     }
 
     long status_code = 0;

--- a/tests/community_proxy_policy_test.cpp
+++ b/tests/community_proxy_policy_test.cpp
@@ -7,6 +7,7 @@ int main()
 {
     using opennow::community_proxy::EnabledUrl;
     using opennow::community_proxy::IsCommunityProxyUrl;
+    using opennow::community_proxy::RuntimeUrl;
 
     const std::string primary =
         "http://client:secret@opennow-proxy-tcp.zortos.me:3128";
@@ -24,15 +25,22 @@ int main()
     assert(!IsCommunityProxyUrl("http://client:secret@proxy.example.com:3128"));
     assert(!IsCommunityProxyUrl(primary + "/unexpected"));
     assert(!IsCommunityProxyUrl(primary + "?redirect=example.com"));
+    assert(RuntimeUrl(primary) == fallback);
+    assert(RuntimeUrl("  client:secret@opennow-proxy-tcp.zortos.me:3128/  ") ==
+           fallback + "/");
+    assert(RuntimeUrl(fallback) == fallback);
+    assert(RuntimeUrl("http://client:secret@proxy.example.com:3128").empty());
 
     opennow::StreamSettings settings;
     settings.community_proxy_url = primary;
     assert(EnabledUrl(settings).empty());
     settings.community_proxy_enabled = true;
-    assert(EnabledUrl(settings) == primary);
+    assert(EnabledUrl(settings) == fallback);
     settings.community_proxy_url =
         "client:secret@opennow-proxy-tcp.zortos.me:3128";
-    assert(EnabledUrl(settings) == primary);
+    assert(EnabledUrl(settings) == fallback);
+    settings.community_proxy_url = fallback;
+    assert(EnabledUrl(settings) == fallback);
     settings.community_proxy_url = "http://client:secret@proxy.example.com:3128";
     assert(EnabledUrl(settings).empty());
     return 0;


### PR DESCRIPTION
## Summary
- Resolve the public community proxy hostname to the pinned runtime endpoint while preserving credentials.
- Configure libcurl explicitly for authenticated HTTP proxy requests and disable bypass rules.
- Expand policy tests for runtime URL normalization and fallback behavior.

## Testing
- `tests/community_proxy_policy_test.cpp` coverage updated for primary, fallback, credentialed, and invalid proxy URLs.
- Full test execution: Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved community proxy URL handling by automatically resolving supported proxy endpoints to a fallback endpoint when needed.
  * Preserved proxy credentials during endpoint resolution.
  * Added explicit HTTP proxy authentication and routing configuration.

* **Bug Fixes**
  * Improved network error messages to indicate when failures occur while using a configured proxy.
  * Invalid proxy URLs are now rejected instead of being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->