### PR TITLE
Add in-stream overlay and Alliance provider login support

### DIFF
--- a/app/src/StreamView.cpp
+++ b/app/src/StreamView.cpp
@@ -1,6 +1,7 @@
 #include "StreamView.hpp"
 #include "controller_layout.hpp"
 #include "input/TouchMapping.hpp"
+#include "keyboard_input_policy.hpp"
 #include "network_utils.hpp"
 #include "nte_autologin_log.hpp"
 #include "stream/ffmpeg/AVFrameHolder.hpp"
@@ -47,76 +48,6 @@ bool IsFreeTier(std::string tier)
     return tier == "FREE";
 }
 
-struct KeyboardStroke {
-    uint16_t keycode = 0;
-    uint16_t scancode = 0;
-    uint16_t modifiers = 0;
-};
-
-bool MapAsciiKey(char character, KeyboardStroke& stroke)
-{
-    constexpr uint16_t kShift = 0x0001;
-    static constexpr uint8_t letter_scans[26] = {
-        0x1e, 0x30, 0x2e, 0x20, 0x12, 0x21, 0x22, 0x23, 0x17, 0x24, 0x25, 0x26, 0x32,
-        0x31, 0x18, 0x19, 0x10, 0x13, 0x1f, 0x14, 0x16, 0x2f, 0x11, 0x2d, 0x15, 0x2c,
-    };
-    if (character >= 'a' && character <= 'z') {
-        const int index = character - 'a';
-        stroke = {static_cast<uint16_t>('A' + index), letter_scans[index], 0};
-        return true;
-    }
-    if (character >= 'A' && character <= 'Z') {
-        const int index = character - 'A';
-        stroke = {static_cast<uint16_t>('A' + index), letter_scans[index], kShift};
-        return true;
-    }
-    if (character >= '1' && character <= '9') {
-        stroke = {static_cast<uint16_t>(character), static_cast<uint16_t>(0x02 + character - '1'), 0};
-        return true;
-    }
-    if (character == '0') {
-        stroke = {'0', 0x0b, 0};
-        return true;
-    }
-
-    switch (character) {
-        case ' ': stroke = {0x20, 0x39, 0}; return true;
-        case '@': stroke = {'2', 0x03, kShift}; return true;
-        case '.': stroke = {0xbe, 0x34, 0}; return true;
-        case ',': stroke = {0xbc, 0x33, 0}; return true;
-        case '-': stroke = {0xbd, 0x0c, 0}; return true;
-        case '_': stroke = {0xbd, 0x0c, kShift}; return true;
-        case '=': stroke = {0xbb, 0x0d, 0}; return true;
-        case '+': stroke = {0xbb, 0x0d, kShift}; return true;
-        case '/': stroke = {0xbf, 0x35, 0}; return true;
-        case '?': stroke = {0xbf, 0x35, kShift}; return true;
-        case '\\': stroke = {0xdc, 0x2b, 0}; return true;
-        case '|': stroke = {0xdc, 0x2b, kShift}; return true;
-        case '[': stroke = {0xdb, 0x1a, 0}; return true;
-        case '{': stroke = {0xdb, 0x1a, kShift}; return true;
-        case ']': stroke = {0xdd, 0x1b, 0}; return true;
-        case '}': stroke = {0xdd, 0x1b, kShift}; return true;
-        case ':': stroke = {0xba, 0x27, kShift}; return true;
-        case ';': stroke = {0xba, 0x27, 0}; return true;
-        case '\'': stroke = {0xde, 0x28, 0}; return true;
-        case '"': stroke = {0xde, 0x28, kShift}; return true;
-        case '`': stroke = {0xc0, 0x29, 0}; return true;
-        case '~': stroke = {0xc0, 0x29, kShift}; return true;
-        case '<': stroke = {0xbc, 0x33, kShift}; return true;
-        case '>': stroke = {0xbe, 0x34, kShift}; return true;
-        case '!': stroke = {'1', 0x02, kShift}; return true;
-        case '#': stroke = {'3', 0x04, kShift}; return true;
-        case '$': stroke = {'4', 0x05, kShift}; return true;
-        case '%': stroke = {'5', 0x06, kShift}; return true;
-        case '^': stroke = {'6', 0x07, kShift}; return true;
-        case '&': stroke = {'7', 0x08, kShift}; return true;
-        case '*': stroke = {'8', 0x09, kShift}; return true;
-        case '(': stroke = {'9', 0x0a, kShift}; return true;
-        case ')': stroke = {'0', 0x0b, kShift}; return true;
-        default: return false;
-    }
-}
-
 int16_t ClampMouseDelta(float value)
 {
     return static_cast<int16_t>(std::clamp<long>(std::lround(value), -32768L, 32767L));
@@ -145,6 +76,8 @@ StreamView::StreamView(
     const auto stream_settings = opennow::LoadStreamSettings();
     debug_diagnostics_ = stream_settings.debug_diagnostics;
     stats_overlay_enabled_ = stream_settings.stats_overlay_enabled;
+    stream_codec_ = stream_settings.codec;
+    stream_region_ = stream_settings.region;
     controller_layout_ = stream_settings.controller_layout;
     opennow::SetStreamDiagnosticsEnabled(debug_diagnostics_);
     free_tier_session_ = auth_.user.membership_tier_verified &&
@@ -198,12 +131,12 @@ void StreamView::SendKeyboardCharacter(char character) {
     if (!session_)
         return;
 
-    KeyboardStroke stroke {};
+    opennow::input::KeyboardStroke stroke {};
     if (character == '\b')
         stroke = {0x08, 0x0e, 0};
     else if (character == '\n' || character == '\r')
         stroke = {0x0d, 0x1c, 0};
-    else if (!MapAsciiKey(character, stroke)) {
+    else if (!opennow::input::MapAsciiKey(character, stroke)) {
         session_->record_ui_event("keyboard unsupported UTF-8 byte=" +
                                   std::to_string(static_cast<unsigned char>(character)));
         return;
@@ -788,6 +721,8 @@ void StreamView::UpdatePerformanceCounter(const VideoPerformanceCounters& counte
             delta(counters.access_unit_bytes, previous_video_counters_.access_unit_bytes)) *
             scale * 8.0f / 1000000.0f;
         network_rtt_ms_ = session_ ? session_->get_network_rtt_ms() : -1;
+        network_counters_ =
+            session_ ? session_->get_network_counters() : StreamNetworkCounters {};
         previous_video_counters_ = counters;
         fps_window_started_ = now;
     }
@@ -822,6 +757,189 @@ void StreamView::DrawPerformanceOverlay(NVGcontext* vg, float x, float y) {
     nvgFillColor(vg, nvgRGB(245, 250, 247));
     nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
     nvgText(vg, box_x + 20.0f, box_y + 23.0f, text, nullptr);
+}
+
+void StreamView::SetStreamOverlayVisible(bool visible)
+{
+    if (stream_overlay_visible_ == visible)
+        return;
+
+    stream_overlay_visible_ = visible;
+    stream_overlay_b_was_down_ = false;
+    gamepad_state_initialized_ = false;
+    plus_was_down_ = false;
+    plus_long_press_ = false;
+    start_pulse_ = {};
+
+    if (touch_was_down_ && session_)
+    {
+        session_->send_mouse_left_button(false);
+        touch_was_down_ = false;
+    }
+    if (session_)
+    {
+        session_->send_gamepad_input(0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f);
+        session_->record_ui_event(
+            visible ? "stream overlay opened by Minus+Plus"
+                    : "stream overlay closed");
+    }
+
+    if (!visible)
+        keyboard_release_guard_ = true;
+}
+
+void StreamView::DrawStreamOverlay(
+    NVGcontext* vg, float x, float y, float width, float height,
+    std::chrono::steady_clock::time_point now)
+{
+    if (!stream_overlay_visible_)
+        return;
+
+    const VideoPerformanceCounters counters = previous_video_counters_;
+    const StreamTransportHealth health =
+        session_ ? session_->get_transport_health() : StreamTransportHealth {};
+    const StreamNetworkCounters network = network_counters_;
+
+    nvgBeginPath(vg);
+    nvgRect(vg, x, y, width, height);
+    nvgFillColor(vg, nvgRGBA(2, 5, 7, 178));
+    nvgFill(vg);
+
+    const float panel_x = x + 34.0f;
+    const float panel_y = y + 28.0f;
+    const float panel_width = width - 68.0f;
+    const float panel_height = height - 56.0f;
+    nvgBeginPath(vg);
+    nvgRoundedRect(vg, panel_x, panel_y, panel_width, panel_height, 20.0f);
+    nvgFillColor(vg, nvgRGBA(13, 17, 20, 246));
+    nvgFill(vg);
+    nvgStrokeWidth(vg, 1.5f);
+    nvgStrokeColor(vg, nvgRGBA(90, 105, 112, 100));
+    nvgStroke(vg);
+
+    nvgFontFaceId(vg, brls::Application::getFont(brls::FONT_REGULAR));
+    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+    nvgFontSize(vg, 13.0f);
+    nvgFillColor(vg, nvgRGB(77, 218, 130));
+    nvgText(vg, panel_x + 30.0f, panel_y + 28.0f, "OPENNOW  /  IN-STREAM MENU", nullptr);
+    nvgFontSize(vg, 26.0f);
+    nvgFillColor(vg, nvgRGB(244, 248, 246));
+    nvgText(vg, panel_x + 30.0f, panel_y + 62.0f,
+            game_title_.empty() ? "GeForce NOW session" : game_title_.c_str(), nullptr);
+    nvgFontSize(vg, 14.0f);
+    nvgFillColor(vg, nvgRGB(142, 153, 160));
+    const std::string provider =
+        auth_.provider.display_name.empty() ? "GeForce NOW" : auth_.provider.display_name;
+    nvgText(vg, panel_x + 30.0f, panel_y + 88.0f,
+            (provider + "  |  B Close  |  Minus + Plus Toggle menu").c_str(), nullptr);
+
+    const float divider_x = panel_x + panel_width * 0.56f;
+    nvgBeginPath(vg);
+    nvgRect(vg, divider_x, panel_y + 112.0f, 1.0f, panel_height - 140.0f);
+    nvgFillColor(vg, nvgRGBA(94, 106, 112, 92));
+    nvgFill(vg);
+
+    const float left_x = panel_x + 30.0f;
+    const float right_x = divider_x + 28.0f;
+    float left_y = panel_y + 132.0f;
+    float right_y = left_y;
+    nvgFontSize(vg, 18.0f);
+    nvgFillColor(vg, nvgRGB(239, 244, 241));
+    nvgText(vg, left_x, left_y, "STREAM STATISTICS", nullptr);
+    nvgText(vg, right_x, right_y, "CONTROLLER SHORTCUTS", nullptr);
+    left_y += 34.0f;
+    right_y += 34.0f;
+
+    auto draw_row = [vg](float row_x, float& row_y, float value_x,
+                         const std::string& label, const std::string& value) {
+        nvgFontSize(vg, 15.0f);
+        nvgFillColor(vg, nvgRGB(139, 150, 157));
+        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+        nvgText(vg, row_x, row_y, label.c_str(), nullptr);
+        nvgFillColor(vg, nvgRGB(238, 244, 240));
+        nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_MIDDLE);
+        nvgText(vg, value_x, row_y, value.c_str(), nullptr);
+        row_y += 31.0f;
+    };
+
+    char number[96];
+    const std::string resolution = session_
+        ? std::to_string(session_->stream_width()) + " x " +
+              std::to_string(session_->stream_height())
+        : "--";
+    draw_row(left_x, left_y, divider_x - 28.0f, "Resolution", resolution);
+    std::snprintf(number, sizeof(number), "%.0f / %.0f / %.0f",
+                  incoming_fps_, decoded_fps_, presented_fps_);
+    draw_row(left_x, left_y, divider_x - 28.0f, "FPS  in / decode / display", number);
+    std::snprintf(number, sizeof(number), "%.1f Mbps", stream_bitrate_mbps_);
+    draw_row(left_x, left_y, divider_x - 28.0f, "Bitrate", number);
+    draw_row(left_x, left_y, divider_x - 28.0f, "Network latency",
+             network_rtt_ms_ >= 0 ? std::to_string(network_rtt_ms_) + " ms" : "-- ms");
+    const std::uint64_t packet_total =
+        static_cast<std::uint64_t>(network.packets_received) + network.sequence_gaps;
+    const double packet_loss = packet_total > 0
+        ? static_cast<double>(network.sequence_gaps) * 100.0 /
+              static_cast<double>(packet_total)
+        : 0.0;
+    std::snprintf(number, sizeof(number), "%.2f%%  (%u gaps / %u late)",
+                  packet_loss, network.sequence_gaps, network.late_packets_dropped);
+    draw_row(left_x, left_y, divider_x - 28.0f, "Packet loss", number);
+    draw_row(left_x, left_y, divider_x - 28.0f, "Dropped video frames",
+             std::to_string(network.access_units_dropped));
+    draw_row(left_x, left_y, divider_x - 28.0f, "NACK recovery requests",
+             std::to_string(network.nack_requests));
+    draw_row(left_x, left_y, divider_x - 28.0f, "Decode latency p95",
+             std::to_string(counters.decode_us_p95 / 1000) + " ms");
+    draw_row(left_x, left_y, divider_x - 28.0f, "Render latency p95",
+             std::to_string(counters.render_us_p95 / 1000) + " ms");
+    draw_row(left_x, left_y, divider_x - 28.0f, "Decoder queue",
+             std::to_string(counters.decode_queue_size) + " / " +
+                 std::to_string(counters.decode_queue_high_water) + " high");
+    draw_row(left_x, left_y, divider_x - 28.0f, "Connection",
+             health.peer_completed ? "Connected" : "Negotiating");
+    draw_row(left_x, left_y, divider_x - 28.0f, "Codec / location",
+             stream_codec_ + "  /  " + stream_region_);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        now - stream_started_at_).count();
+    std::snprintf(number, sizeof(number), "%lld:%02lld",
+                  static_cast<long long>(elapsed / 60),
+                  static_cast<long long>(elapsed % 60));
+    draw_row(left_x, left_y, divider_x - 28.0f, "Session time", number);
+
+    auto draw_shortcut = [vg, right_x](
+                             float& row_y, const char* keys, const char* action) {
+        const float key_width = 126.0f;
+        nvgBeginPath(vg);
+        nvgRoundedRect(vg, right_x, row_y - 13.0f, key_width, 28.0f, 6.0f);
+        nvgFillColor(vg, nvgRGBA(39, 47, 51, 230));
+        nvgFill(vg);
+        nvgStrokeWidth(vg, 1.0f);
+        nvgStrokeColor(vg, nvgRGBA(113, 129, 137, 130));
+        nvgStroke(vg);
+        nvgFontSize(vg, 14.0f);
+        nvgFillColor(vg, nvgRGB(240, 245, 242));
+        nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+        nvgText(vg, right_x + key_width * 0.5f, row_y + 1.0f, keys, nullptr);
+        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+        nvgFillColor(vg, nvgRGB(188, 198, 202));
+        nvgText(vg, right_x + key_width + 18.0f, row_y + 1.0f, action, nullptr);
+        row_y += 42.0f;
+    };
+
+    draw_shortcut(right_y, "Minus + Plus", "Open / close this menu");
+    draw_shortcut(right_y, "Minus + Y", "On-screen keyboard");
+    draw_shortcut(right_y, "B", "Close menu or keyboard");
+    draw_shortcut(right_y, "ZL + ZR + Minus", "Exit the stream");
+    draw_shortcut(right_y, "Hold +", "Xbox Guide button");
+    draw_shortcut(right_y, "Touch", "Remote pointer and click");
+    if (is_nte_session_)
+        draw_shortcut(right_y, "L + X", "NTE auto-login");
+
+    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+    nvgFontSize(vg, 13.0f);
+    nvgFillColor(vg, nvgRGB(103, 116, 122));
+    nvgText(vg, right_x, panel_y + panel_height - 26.0f,
+            "Menu input stays local and is never sent to the cloud game.", nullptr);
 }
 
 void StreamView::DrawNteAutoLoginStatus(
@@ -1095,7 +1213,7 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
 
         const auto input_now = std::chrono::steady_clock::now();
         bool nte_owned_input = false;
-        if (is_nte_session_ &&
+        if (is_nte_session_ && !stream_overlay_visible_ &&
             stream_end_reason_ == opennow::StreamEndReason::None) {
             const bool nte_combo = state.buttons[brls::BUTTON_LB] &&
                                    state.buttons[brls::BUTTON_X];
@@ -1113,11 +1231,44 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
             nte_owned_input = was_active || nte_combo;
         }
 
-        const bool keyboard_combo = state.buttons[brls::BUTTON_BACK] &&
-                                    state.buttons[brls::BUTTON_Y];
-        bool keyboard_owned_input = keyboard_visible_ || nte_owned_input ||
-            stream_end_reason_ != opennow::StreamEndReason::None;
+        const bool minus_down = state.buttons[brls::BUTTON_BACK];
+        const bool plus_down_for_overlay = state.buttons[brls::BUTTON_START];
+        const auto chord_now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            input_now.time_since_epoch()).count();
+        const auto overlay_decision = opennow::input::EvaluateOverlayChord(
+            minus_down, plus_down_for_overlay, overlay_chord_state_, chord_now_ms);
+        overlay_chord_state_ = overlay_decision.next_state;
+        if (!minus_down && !plus_down_for_overlay)
+            overlay_chord_latched_ = false;
+        if (overlay_decision.toggle_overlay && !overlay_chord_latched_ &&
+            !keyboard_visible_ && !nte_owned_input &&
+            stream_end_reason_ == opennow::StreamEndReason::None)
+        {
+            overlay_chord_latched_ = true;
+            SetStreamOverlayVisible(!stream_overlay_visible_);
+        }
+
+        if (stream_overlay_visible_)
+        {
+            const bool b_down = state.buttons[brls::BUTTON_B];
+            if (b_down && !stream_overlay_b_was_down_)
+            {
+                suppress_b_until_release_ = true;
+                SetStreamOverlayVisible(false);
+            }
+            stream_overlay_b_was_down_ = b_down;
+        }
+        else
+        {
+            stream_overlay_b_was_down_ = false;
+        }
+
+        const bool keyboard_combo = minus_down && state.buttons[brls::BUTTON_Y];
+        bool keyboard_owned_input = keyboard_visible_ || stream_overlay_visible_ ||
+            overlay_decision.preempt_input || overlay_chord_latched_ ||
+            nte_owned_input || stream_end_reason_ != opennow::StreamEndReason::None;
         if (keyboard_combo && !keyboard_combo_was_down_ && !nte_owned_input &&
+            !stream_overlay_visible_ &&
             stream_end_reason_ == opennow::StreamEndReason::None) {
             OpenInlineKeyboard();
             keyboard_owned_input = keyboard_visible_;
@@ -1354,6 +1505,8 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
     DrawStreamEndNotice(vg, x, y, width, notice_now);
     if (stream_end_reason_ == opennow::StreamEndReason::None)
         DrawNteAutoLoginStatus(vg, x, y, width, height, notice_now);
+    if (stream_end_reason_ == opennow::StreamEndReason::None)
+        DrawStreamOverlay(vg, x, y, width, height, notice_now);
 
     brls::Box::draw(vg, x, y, width, height, style, ctx);
 }

--- a/app/src/StreamView.hpp
+++ b/app/src/StreamView.hpp
@@ -3,6 +3,7 @@
 #include "gfn_client.hpp"
 #include "controller_delivery_policy.hpp"
 #include "nte_credentials.hpp"
+#include "stream_overlay_policy.hpp"
 #include "webrtc_session.hpp"
 #include <memory>
 #include <vector>
@@ -47,6 +48,9 @@ private:
     void DrawPreparingStream(NVGcontext* vg, float x, float y, float width, float height);
     void UpdatePerformanceCounter(const VideoPerformanceCounters& counters);
     void DrawPerformanceOverlay(NVGcontext* vg, float x, float y);
+    void SetStreamOverlayVisible(bool visible);
+    void DrawStreamOverlay(NVGcontext* vg, float x, float y, float width, float height,
+                           std::chrono::steady_clock::time_point now);
     void UpdateSessionLimitNotice(std::chrono::steady_clock::time_point now);
     void DrawSessionLimitNotice(NVGcontext* vg, float x, float y, float width,
                                 std::chrono::steady_clock::time_point now);
@@ -104,6 +108,12 @@ private:
     bool cloud_stop_requested_ = false;
     bool debug_diagnostics_ = false;
     bool stats_overlay_enabled_ = false;
+    bool stream_overlay_visible_ = false;
+    bool stream_overlay_b_was_down_ = false;
+    bool overlay_chord_latched_ = false;
+    opennow::input::OverlayChordState overlay_chord_state_;
+    std::string stream_codec_ = "H264";
+    std::string stream_region_ = "Auto";
     std::string controller_layout_ = "Xbox";
     bool show_debug_overlay_ = false;
     bool is_nte_session_ = false;
@@ -146,6 +156,7 @@ private:
     float presented_fps_ = 0.0f;
     float stream_bitrate_mbps_ = 0.0f;
     int network_rtt_ms_ = -1;
+    StreamNetworkCounters network_counters_ {};
     bool gamepad_state_initialized_ = false;
     uint16_t last_gamepad_buttons_ = 0;
     uint8_t last_left_trigger_ = 0;

--- a/app/src/gfn/authentication.cpp
+++ b/app/src/gfn/authentication.cpp
@@ -568,7 +568,7 @@ AuthSession GfnClient::RecoverSavedSession(
 {
     if (session.reauthentication_required)
         throw ReauthenticationRequired(
-            "The NVIDIA session expired. Reconnect this account with a QR code.");
+            "The saved session expired. Reconnect this account with a QR code.");
 
     try
     {
@@ -581,7 +581,7 @@ AuthSession GfnClient::RecoverSavedSession(
     catch (const ReauthenticationRequired&)
     {
         throw ReauthenticationRequired(
-            "The NVIDIA session expired. Reconnect this account with a QR code.");
+            "The saved session expired. Reconnect this account with a QR code.");
     }
 }
 
@@ -630,7 +630,7 @@ AuthSession GfnClient::LoginWithQrCode(
         challenge.verification_uri.empty() || challenge.verification_uri_complete.empty())
     {
         throw std::runtime_error(
-            "NVIDIA did not return the data required for QR login");
+            "The login provider did not return the data required for QR login");
     }
 
     if (on_challenge)

--- a/app/src/keyboard_input_policy.hpp
+++ b/app/src/keyboard_input_policy.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cstdint>
+
+namespace opennow::input
+{
+
+struct KeyboardStroke
+{
+    std::uint16_t keycode   = 0;
+    std::uint16_t scancode  = 0;
+    std::uint16_t modifiers = 0;
+};
+
+inline bool MapAsciiKey(char character, KeyboardStroke& stroke)
+{
+    constexpr std::uint16_t kShift = 0x0001;
+    static constexpr std::uint8_t letter_scans[26] = {
+        0x1e, 0x30, 0x2e, 0x20, 0x12, 0x21, 0x22, 0x23, 0x17, 0x24, 0x25, 0x26, 0x32,
+        0x31, 0x18, 0x19, 0x10, 0x13, 0x1f, 0x14, 0x16, 0x2f, 0x11, 0x2d, 0x15, 0x2c,
+    };
+    if (character >= 'a' && character <= 'z')
+    {
+        const int index = character - 'a';
+        stroke = {static_cast<std::uint16_t>('A' + index), letter_scans[index], 0};
+        return true;
+    }
+    if (character >= 'A' && character <= 'Z')
+    {
+        const int index = character - 'A';
+        stroke = {static_cast<std::uint16_t>('A' + index), letter_scans[index], kShift};
+        return true;
+    }
+    if (character >= '1' && character <= '9')
+    {
+        stroke = {
+            static_cast<std::uint16_t>(character),
+            static_cast<std::uint16_t>(0x02 + character - '1'),
+            0,
+        };
+        return true;
+    }
+    if (character == '0')
+    {
+        stroke = {'0', 0x0b, 0};
+        return true;
+    }
+
+    switch (character)
+    {
+        case ' ': stroke = {0x20, 0x39, 0}; return true;
+        case '@': stroke = {'2', 0x03, kShift}; return true;
+        case '.': stroke = {0xbe, 0x34, 0}; return true;
+        case ',': stroke = {0xbc, 0x33, 0}; return true;
+        case '-': stroke = {0xbd, 0x0c, 0}; return true;
+        case '_': stroke = {0xbd, 0x0c, kShift}; return true;
+        case '=': stroke = {0xbb, 0x0d, 0}; return true;
+        case '+': stroke = {0xbb, 0x0d, kShift}; return true;
+        case '/': stroke = {0xbf, 0x35, 0}; return true;
+        case '?': stroke = {0xbf, 0x35, kShift}; return true;
+        case '\\': stroke = {0xdc, 0x2b, 0}; return true;
+        case '|': stroke = {0xdc, 0x2b, kShift}; return true;
+        case '[': stroke = {0xdb, 0x1a, 0}; return true;
+        case '{': stroke = {0xdb, 0x1a, kShift}; return true;
+        case ']': stroke = {0xdd, 0x1b, 0}; return true;
+        case '}': stroke = {0xdd, 0x1b, kShift}; return true;
+        case ':': stroke = {0xba, 0x27, kShift}; return true;
+        case ';': stroke = {0xba, 0x27, 0}; return true;
+        case '\'': stroke = {0xde, 0x28, 0}; return true;
+        case '"': stroke = {0xde, 0x28, kShift}; return true;
+        case '`': stroke = {0xc0, 0x29, 0}; return true;
+        case '~': stroke = {0xc0, 0x29, kShift}; return true;
+        case '<': stroke = {0xbc, 0x33, kShift}; return true;
+        case '>': stroke = {0xbe, 0x34, kShift}; return true;
+        case '!': stroke = {'1', 0x02, kShift}; return true;
+        case '#': stroke = {'3', 0x04, kShift}; return true;
+        case '$': stroke = {'4', 0x05, kShift}; return true;
+        case '%': stroke = {'5', 0x06, kShift}; return true;
+        case '^': stroke = {'6', 0x07, kShift}; return true;
+        case '&': stroke = {'7', 0x08, kShift}; return true;
+        case '*': stroke = {'8', 0x09, kShift}; return true;
+        case '(': stroke = {'9', 0x0a, kShift}; return true;
+        case ')': stroke = {'0', 0x0b, kShift}; return true;
+        default: return false;
+    }
+}
+
+} // namespace opennow::input

--- a/app/src/main_activity.cpp
+++ b/app/src/main_activity.cpp
@@ -121,7 +121,9 @@ class StartupGateView final : public brls::Box
         card->setCornerRadius(18);
 
         auto* eyebrow = new brls::Label();
-        eyebrow->setText(Tr("SAVED NVIDIA ACCOUNT"));
+        const std::string provider = saved.provider.display_name.empty()
+            ? "GEFORCE NOW" : saved.provider.display_name;
+        eyebrow->setText(Tr("SAVED ACCOUNT") + "  /  " + provider);
         eyebrow->setFontSize(13);
         eyebrow->setTextColor(nvgRGB(77, 218, 130));
         eyebrow->setHorizontalAlign(brls::HorizontalAlign::CENTER);
@@ -186,7 +188,7 @@ class StartupGateView final : public brls::Box
         brls::async([this, alive, client = std::move(client), saved = std::move(saved)]() mutable {
             try
             {
-                SetStatus("Checking NVIDIA session",
+                SetStatus("Checking saved session",
                           "Refreshing authorization and verifying account access.");
                 AuthSession verified = client.RecoverSavedSession(saved, true);
 
@@ -194,7 +196,7 @@ class StartupGateView final : public brls::Box
                     return;
                 SetStatus("Account verified", "Loading OpenNOW and your saved profile.");
                 verified.reauthentication_required = false;
-                Complete(std::move(verified), "NVIDIA account is ready");
+                Complete(std::move(verified), "GeForce NOW account is ready");
             }
             catch (const ReauthenticationRequired& ex)
             {
@@ -202,7 +204,7 @@ class StartupGateView final : public brls::Box
                     return;
                 saved.reauthentication_required = true;
                 Complete(std::move(saved),
-                         "NVIDIA requires a new QR code sign-in from Library");
+                         "The provider requires a new QR code sign-in from Settings");
                 brls::Logger::warning("Startup sign-in requires QR reconnection: {}", ex.what());
             }
             catch (const std::exception& ex)

--- a/app/src/main_tabs_view.cpp
+++ b/app/src/main_tabs_view.cpp
@@ -31,7 +31,7 @@ MainTabsView::MainTabsView()
             {
                 session.reauthentication_required = true;
                 brls::Application::notify(
-                    "NVIDIA session expired; reconnect with a QR code from Library");
+                    "Saved session expired; reconnect the account from Settings");
             }
             catch (const std::exception&)
             {
@@ -93,7 +93,7 @@ void MainTabsView::MaybeRefreshAuthentication()
                     invalid.reauthentication_required = true;
                     current.SetSession(std::move(invalid));
                     brls::Application::notify(
-                        "NVIDIA session expired; reconnect with a QR code from Library");
+                        "Saved session expired; reconnect the account from Settings");
                 }
                 guard->store(false);
             });

--- a/app/src/providers_tab.cpp
+++ b/app/src/providers_tab.cpp
@@ -5,6 +5,8 @@
 #include "qr_login_dialog.hpp"
 #include "localization.hpp"
 
+#include <utility>
+
 namespace opennow
 {
 namespace
@@ -35,18 +37,21 @@ class InputBlocker
 
 } // namespace
 
-ProvidersTab::ProvidersTab()
+ProvidersTab::ProvidersTab(std::function<void()> on_success)
     : brls::Box(brls::Axis::COLUMN)
+    , on_success_(std::move(on_success))
 {
     setPadding(28, 40, 28, 40);
 
     auto* header = new brls::Header();
-    header->setTitle("Providers");
-    header->setSubtitle("Add another GeForce NOW account");
+    header->setTitle("Choose a login provider");
+    header->setSubtitle("NVIDIA and GeForce NOW Alliance partners");
     addView(header);
 
     addView(MakeParagraph(
-        "Choose an NVIDIA identity provider. SwitchNOW signs in internally with the Switch keyboard; QR/LAN is only a fallback for CAPTCHA or passkey. Saved tokens refresh automatically.", 20.0f));
+        "Choose the company that operates GeForce NOW for your account. "
+        "The list comes from GeForce NOW and includes supported Alliance partners. "
+        "Saved tokens refresh automatically.", 20.0f));
 
     auto* refresh_button = new brls::Button();
     refresh_button->setStyle(&brls::BUTTONSTYLE_PRIMARY);
@@ -125,7 +130,10 @@ void ProvidersTab::RebuildList()
     {
         const LoginProvider& provider = providers_[index];
         auto* button                  = new brls::Button();
-        button->setText(provider.display_name + "  [" + provider.code + "]");
+        const std::string provider_type =
+            provider.code == "NVIDIA" ? "NVIDIA" : "Alliance";
+        button->setText(
+            provider.display_name + "  [" + provider_type + " / " + provider.code + "]");
         button->setMarginBottom(10);
         button->registerClickAction([this, index](brls::View* view) {
             return OpenProviderDialog(view, index);
@@ -141,7 +149,15 @@ bool ProvidersTab::OpenProviderDialog(brls::View* view, size_t index)
 
     const LoginProvider& provider = providers_[index];
     
-    auto* dialog = new QrLoginDialog(provider, client_);
+    auto* dialog = new QrLoginDialog(provider, client_, [this]() {
+        // QrLoginDialog first removes itself. Queue the second pop so the
+        // provider picker closes on the following UI turn.
+        brls::sync([this]() {
+            if (on_success_)
+                on_success_();
+            brls::Application::popActivity();
+        });
+    });
     brls::Application::pushActivity(new brls::Activity(dialog));
     
     return true;

--- a/app/src/providers_tab.hpp
+++ b/app/src/providers_tab.hpp
@@ -5,6 +5,7 @@
 
 #include <borealis.hpp>
 
+#include <functional>
 #include <vector>
 
 namespace opennow
@@ -13,7 +14,7 @@ namespace opennow
 class ProvidersTab : public brls::Box
 {
   public:
-    ProvidersTab();
+    explicit ProvidersTab(std::function<void()> on_success = {});
 
     void willAppear(bool resetState) override;
 
@@ -27,6 +28,7 @@ class ProvidersTab : public brls::Box
     brls::Label* status_label_             = nullptr;
     brls::ScrollingFrame* scrolling_frame_ = nullptr;
     brls::Box* list_container_             = nullptr;
+    std::function<void()> on_success_;
     bool loading_                          = false;
 };
 

--- a/app/src/qr_login_dialog.cpp
+++ b/app/src/qr_login_dialog.cpp
@@ -24,7 +24,9 @@ QrLoginDialog::QrLoginDialog(
     setAlignItems(brls::AlignItems::CENTER);
 
     auto* header = new brls::Header();
-    header->setTitle(Tr("Sign in with QR code"));
+    const std::string provider_name =
+        provider_.display_name.empty() ? "GeForce NOW" : provider_.display_name;
+    header->setTitle(Tr("Sign in with QR code") + "  /  " + provider_name);
     header->setMarginBottom(14);
     addView(header);
 
@@ -38,7 +40,7 @@ QrLoginDialog::QrLoginDialog(
 
     instruction_label_ = new brls::Label();
     instruction_label_->setText(
-        Tr("Scan the code with your phone, approve the NVIDIA sign-in, and return here."));
+        Tr("Scan the code with your phone, approve the provider sign-in, and return here."));
     instruction_label_->setFontSize(17);
     instruction_label_->setHorizontalAlign(brls::HorizontalAlign::CENTER);
     instruction_label_->setTextColor(nvgRGB(145, 153, 165));
@@ -142,7 +144,8 @@ void QrLoginDialog::StartLogin()
     is_cancelled_.store(false);
     status_label_->setText(Tr("Preparing secure QR login..."));
     instruction_label_->setText(
-        Tr("Requesting a short-lived device code directly from NVIDIA."));
+        Tr("Requesting a short-lived device code for ") +
+        (provider_.display_name.empty() ? "GeForce NOW" : provider_.display_name) + ".");
     user_code_label_->setText("");
     {
         std::lock_guard<std::mutex> lock(qr_mutex_);
@@ -165,7 +168,7 @@ void QrLoginDialog::StartLogin()
                             return;
                         status_label_->setText(Tr("Scan to sign in"));
                         instruction_label_->setText(Tr(
-                            "Open your camera, scan the QR code, then approve the NVIDIA request."));
+                            "Open your camera, scan the QR code, then approve the provider request."));
                         user_code_label_->setText(
                             Tr("Code: ") + challenge.user_code);
                     });

--- a/app/src/settings_tab.cpp
+++ b/app/src/settings_tab.cpp
@@ -5,6 +5,7 @@
 #include "home_shortcut.hpp"
 #include "localization.hpp"
 #include "membership_tier_policy.hpp"
+#include "providers_tab.hpp"
 #include "qr_login_dialog.hpp"
 #include "server_location_policy.hpp"
 #include "stream_settings.hpp"
@@ -500,7 +501,7 @@ void SettingsTab::BuildAccountPage()
         state.HasSession() && state.session()->reauthentication_required
             ? "Reconnect account"
             : "Add account",
-        "Connect with NVIDIA using a QR code.",
+        "Connect with NVIDIA or a GeForce NOW Alliance partner using a QR code.",
         state.HasSession() && state.session()->reauthentication_required ? "Reconnect" : "Add",
         [this](brls::View* view) { return BeginLogin(view); }));
     actions->addView(MakeActionRow(
@@ -791,15 +792,21 @@ bool SettingsTab::BeginLogin(brls::View* view)
         if (providers.empty())
             throw std::runtime_error("No GeForce NOW login providers were returned");
 
-        const LoginProvider provider =
-            state.HasSession() && state.session()->reauthentication_required
-            ? state.session()->provider
-            : providers.front();
-        auto* dialog = new QrLoginDialog(provider, client_, [this]() {
+        const auto refresh_account = [this]() {
             RefreshSummary();
             RebuildCategory();
-        });
-        brls::Application::pushActivity(new brls::Activity(dialog));
+        };
+        if (state.HasSession() && state.session()->reauthentication_required)
+        {
+            auto* dialog = new QrLoginDialog(
+                state.session()->provider, client_, refresh_account);
+            brls::Application::pushActivity(new brls::Activity(dialog));
+        }
+        else
+        {
+            auto* providers_view = new ProvidersTab(refresh_account);
+            brls::Application::pushActivity(new brls::Activity(providers_view));
+        }
     }
     catch (const std::exception& ex)
     {

--- a/app/src/stream_overlay_policy.hpp
+++ b/app/src/stream_overlay_policy.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+
+namespace opennow::input
+{
+
+enum class OverlayChordHalf
+{
+    None,
+    Minus,
+    Plus,
+};
+
+struct OverlayChordState
+{
+    OverlayChordHalf pending_half = OverlayChordHalf::None;
+    std::int64_t pending_since_ms = 0;
+    bool disqualified             = false;
+};
+
+struct OverlayChordDecision
+{
+    bool toggle_overlay = false;
+    bool preempt_input  = false;
+    OverlayChordState next_state;
+};
+
+inline OverlayChordDecision EvaluateOverlayChord(
+    bool minus_pressed,
+    bool plus_pressed,
+    const OverlayChordState& state,
+    std::int64_t now_ms,
+    std::int64_t grace_ms = 120)
+{
+    if (minus_pressed && plus_pressed)
+    {
+        if (state.disqualified)
+            return {false, false, state};
+        return {true, true, {}};
+    }
+
+    const OverlayChordHalf pressed_half =
+        minus_pressed == plus_pressed
+            ? OverlayChordHalf::None
+            : (minus_pressed ? OverlayChordHalf::Minus : OverlayChordHalf::Plus);
+    if (pressed_half == OverlayChordHalf::None)
+        return {};
+
+    if (state.disqualified)
+    {
+        OverlayChordState next = state;
+        if (state.pending_half != pressed_half)
+            next = {pressed_half, now_ms, true};
+        return {false, false, next};
+    }
+
+    if (state.pending_half == OverlayChordHalf::None ||
+        state.pending_half != pressed_half)
+    {
+        return {false, true, {pressed_half, now_ms, false}};
+    }
+
+    OverlayChordState next = state;
+    next.disqualified = now_ms - state.pending_since_ms >= grace_ms;
+    return {false, !next.disqualified, next};
+}
+
+} // namespace opennow::input

--- a/app/src/webrtc/diagnostics.cpp
+++ b/app/src/webrtc/diagnostics.cpp
@@ -337,6 +337,21 @@ int WebRtcSession::get_network_rtt_ms() const {
     return pc_ ? peer_connection_get_rtt_ms(pc_) : -1;
 }
 
+StreamNetworkCounters WebRtcSession::get_network_counters() const {
+    std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
+    PeerVideoRtpStats stats {};
+    if (pc_)
+        (void)peer_connection_get_video_rtp_stats(pc_, &stats);
+
+    StreamNetworkCounters counters;
+    counters.packets_received = stats.packets_received;
+    counters.sequence_gaps = stats.sequence_gaps;
+    counters.late_packets_dropped = stats.late_packets_dropped;
+    counters.access_units_dropped = stats.access_units_dropped;
+    counters.nack_requests = stats.nack_requests;
+    return counters;
+}
+
 StreamTransportHealth WebRtcSession::get_transport_health() const {
     StreamTransportHealth health;
     health.peer_completed = peer_ever_completed_.load(std::memory_order_acquire);

--- a/app/src/webrtc_session.hpp
+++ b/app/src/webrtc_session.hpp
@@ -49,6 +49,14 @@ struct StreamTransportHealth {
     std::chrono::milliseconds video_idle {0};
 };
 
+struct StreamNetworkCounters {
+    std::uint32_t packets_received = 0;
+    std::uint32_t sequence_gaps = 0;
+    std::uint32_t late_packets_dropped = 0;
+    std::uint32_t access_units_dropped = 0;
+    std::uint32_t nack_requests = 0;
+};
+
 class WebRtcSession {
 public:
     WebRtcSession(
@@ -91,6 +99,7 @@ public:
     int64_t video_target_rtp_timestamp() const;
     VideoPerformanceCounters get_video_performance() const;
     int get_network_rtt_ms() const;
+    StreamNetworkCounters get_network_counters() const;
     StreamTransportHealth get_transport_health() const;
     std::string get_debug_info() const;
     bool is_terminal() const { return peer_terminal_.load(std::memory_order_acquire); }

--- a/tests/keyboard_input_policy_test.cpp
+++ b/tests/keyboard_input_policy_test.cpp
@@ -1,0 +1,28 @@
+#include "keyboard_input_policy.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using opennow::input::KeyboardStroke;
+    using opennow::input::MapAsciiKey;
+
+    KeyboardStroke stroke;
+    assert(MapAsciiKey('a', stroke));
+    assert(stroke.keycode == 'A' && stroke.scancode == 0x1e && stroke.modifiers == 0);
+
+    assert(MapAsciiKey('A', stroke));
+    assert(stroke.keycode == 'A' && stroke.scancode == 0x1e && stroke.modifiers == 0x0001);
+
+    assert(MapAsciiKey('@', stroke));
+    assert(stroke.keycode == '2' && stroke.scancode == 0x03 && stroke.modifiers == 0x0001);
+
+    assert(MapAsciiKey('?', stroke));
+    assert(stroke.keycode == 0xbf && stroke.scancode == 0x35 && stroke.modifiers == 0x0001);
+
+    assert(MapAsciiKey(' ', stroke));
+    assert(stroke.keycode == 0x20 && stroke.scancode == 0x39 && stroke.modifiers == 0);
+
+    assert(!MapAsciiKey('\t', stroke));
+    return 0;
+}

--- a/tests/stream_overlay_policy_test.cpp
+++ b/tests/stream_overlay_policy_test.cpp
@@ -1,0 +1,40 @@
+#include "stream_overlay_policy.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using namespace opennow::input;
+
+    OverlayChordState state;
+    auto decision = EvaluateOverlayChord(true, false, state, 1000);
+    assert(!decision.toggle_overlay);
+    assert(decision.preempt_input);
+    state = decision.next_state;
+
+    decision = EvaluateOverlayChord(true, true, state, 1050);
+    assert(decision.toggle_overlay);
+    assert(decision.preempt_input);
+
+    state = {};
+    decision = EvaluateOverlayChord(false, true, state, 2000);
+    assert(!decision.toggle_overlay);
+    assert(decision.preempt_input);
+    state = decision.next_state;
+
+    decision = EvaluateOverlayChord(false, true, state, 2120);
+    assert(!decision.toggle_overlay);
+    assert(!decision.preempt_input);
+    assert(decision.next_state.disqualified);
+
+    state = decision.next_state;
+    decision = EvaluateOverlayChord(true, true, state, 2130);
+    assert(!decision.toggle_overlay);
+    assert(!decision.preempt_input);
+
+    decision = EvaluateOverlayChord(false, false, state, 2200);
+    assert(!decision.toggle_overlay);
+    assert(!decision.preempt_input);
+    assert(decision.next_state.pending_half == OverlayChordHalf::None);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add an in-stream diagnostics overlay with stream, network, decoder, and controller shortcut information.
- Support Minus + Plus overlay toggling and Minus + Y on-screen keyboard input handling.
- Add GeForce NOW Alliance provider selection and provider-aware QR login flows.
- Generalize saved-session and login messaging beyond NVIDIA-only accounts.
- Extract keyboard and overlay input policies with host-side tests.

## Testing

- Added `keyboard_input_policy_test.cpp` coverage for ASCII keyboard mapping.
- Added `stream_overlay_policy_test.cpp` coverage for overlay chord behavior.
- Not run: host test compilation/execution.
- Not run: Switch/devkitPro build and hardware stream validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-stream overlay showing codec, location, packet-loss, and controller shortcut information.
  * Added controller shortcuts to open and close the overlay.
  * Expanded QR sign-in to support multiple providers and Alliance partners.
  * Improved provider-specific sign-in instructions and completion behavior.
* **Bug Fixes**
  * Updated saved-session expiration and reauthentication messages for clarity.
  * Improved account status messaging during startup and sign-in.
* **Performance**
  * Added stream network diagnostics, including packet-loss and dropped-packet metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->