### PR TITLE
Add keyboard shortcut chords to inline keyboard

### DIFF
--- a/app/src/StreamView.cpp
+++ b/app/src/StreamView.cpp
@@ -244,6 +244,22 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
         if (keyboard_visible_) {
             const bool b_down = state.buttons[brls::BUTTON_B];
             const bool plus_down = state.buttons[brls::BUTTON_START];
+            const bool escape_chord = minus_down && state.buttons[brls::BUTTON_LT];
+            const bool tab_chord = minus_down && state.buttons[brls::BUTTON_LB];
+            const bool alt_tab_chord = minus_down && state.buttons[brls::BUTTON_RB];
+            const bool windows_chord = minus_down && state.buttons[brls::BUTTON_RT];
+            if (escape_chord && !keyboard_escape_chord_was_down_)
+                SendKeyboardShortcut(opennow::input::KeyboardShortcut::Escape);
+            else if (tab_chord && !keyboard_tab_chord_was_down_)
+                SendKeyboardShortcut(opennow::input::KeyboardShortcut::Tab);
+            else if (alt_tab_chord && !keyboard_alt_tab_chord_was_down_)
+                SendKeyboardShortcut(opennow::input::KeyboardShortcut::AltTab);
+            else if (windows_chord && !keyboard_windows_chord_was_down_)
+                SendKeyboardShortcut(opennow::input::KeyboardShortcut::Windows);
+            keyboard_escape_chord_was_down_ = escape_chord;
+            keyboard_tab_chord_was_down_ = tab_chord;
+            keyboard_alt_tab_chord_was_down_ = alt_tab_chord;
+            keyboard_windows_chord_was_down_ = windows_chord;
             if (plus_down && !keyboard_plus_was_down_)
                 HideInlineKeyboard(true);
             else if (b_down && !keyboard_b_was_down_)
@@ -254,6 +270,10 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
         } else {
             keyboard_b_was_down_ = false;
             keyboard_plus_was_down_ = false;
+            keyboard_escape_chord_was_down_ = false;
+            keyboard_tab_chord_was_down_ = false;
+            keyboard_alt_tab_chord_was_down_ = false;
+            keyboard_windows_chord_was_down_ = false;
         }
 
         if (!state.buttons[brls::BUTTON_B])

--- a/app/src/StreamView.hpp
+++ b/app/src/StreamView.hpp
@@ -2,6 +2,7 @@
 #include <borealis.hpp>
 #include "gfn_client.hpp"
 #include "controller_delivery_policy.hpp"
+#include "keyboard_input_policy.hpp"
 #include "network_utils.hpp"
 #include "nte_credentials.hpp"
 #include "stream_end_policy.hpp"
@@ -73,6 +74,7 @@ private:
     void UpdateInlineKeyboard();
     void HandleKeyboardText(const char* text);
     void SendKeyboardCharacter(char character);
+    void SendKeyboardShortcut(opennow::input::KeyboardShortcut shortcut);
     void StartNteAutoLogin(std::chrono::steady_clock::time_point now);
     void CancelNteAutoLogin();
     void UpdateNteAutoLogin(std::chrono::steady_clock::time_point now);
@@ -149,6 +151,10 @@ private:
     bool keyboard_combo_was_down_ = false;
     bool keyboard_b_was_down_ = false;
     bool keyboard_plus_was_down_ = false;
+    bool keyboard_escape_chord_was_down_ = false;
+    bool keyboard_tab_chord_was_down_ = false;
+    bool keyboard_alt_tab_chord_was_down_ = false;
+    bool keyboard_windows_chord_was_down_ = false;
     bool suppress_b_until_release_ = false;
     bool keyboard_release_guard_ = false;
     bool keyboard_visible_ = false;

--- a/app/src/keyboard_input_policy.hpp
+++ b/app/src/keyboard_input_policy.hpp
@@ -12,6 +12,30 @@ struct KeyboardStroke
     std::uint16_t modifiers = 0;
 };
 
+enum class KeyboardShortcut
+{
+    Escape,
+    Tab,
+    AltTab,
+    Windows,
+};
+
+inline KeyboardStroke MapKeyboardShortcut(KeyboardShortcut shortcut)
+{
+    constexpr std::uint16_t kAlt  = 0x0004;
+    constexpr std::uint16_t kMeta = 0x0008;
+
+    switch (shortcut)
+    {
+        case KeyboardShortcut::Escape: return {0x1b, 0x01, 0};
+        case KeyboardShortcut::Tab: return {0x09, 0x0f, 0};
+        case KeyboardShortcut::AltTab: return {0x09, 0x0f, kAlt};
+        case KeyboardShortcut::Windows: return {0x5b, 0x5b, kMeta};
+    }
+
+    return {};
+}
+
 inline bool MapAsciiKey(char character, KeyboardStroke& stroke)
 {
     constexpr std::uint16_t kShift = 0x0001;

--- a/app/src/stream_view_input.cpp
+++ b/app/src/stream_view_input.cpp
@@ -35,6 +35,15 @@ void StreamView::SendKeyboardCharacter(char character) {
     session_->send_keyboard_key(stroke.keycode, stroke.scancode, stroke.modifiers, false);
 }
 
+void StreamView::SendKeyboardShortcut(opennow::input::KeyboardShortcut shortcut) {
+    if (!session_)
+        return;
+
+    const auto stroke = opennow::input::MapKeyboardShortcut(shortcut);
+    session_->send_keyboard_key(stroke.keycode, stroke.scancode, stroke.modifiers, true);
+    session_->send_keyboard_key(stroke.keycode, stroke.scancode, stroke.modifiers, false);
+}
+
 void StreamView::SendNteClick(float normalized_x, float normalized_y) {
     if (!session_) {
         opennow::AppendNteAutoLoginLog("CLICK skipped reason=no_session");
@@ -310,6 +319,10 @@ void StreamView::OpenInlineKeyboard() {
     keyboard_visible_ = true;
     keyboard_b_was_down_ = false;
     keyboard_plus_was_down_ = false;
+    keyboard_escape_chord_was_down_ = false;
+    keyboard_tab_chord_was_down_ = false;
+    keyboard_alt_tab_chord_was_down_ = false;
+    keyboard_windows_chord_was_down_ = false;
     gamepad_state_initialized_ = false;
     if (touch_was_down_) {
         session_->send_mouse_left_button(false);
@@ -317,6 +330,8 @@ void StreamView::OpenInlineKeyboard() {
     }
     session_->send_gamepad_input(0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f);
     session_->record_ui_event("keyboard opened by Minus+Y");
+    brls::Application::notify(
+        "Keyboard shortcuts: MINUS + ZL Esc / L Tab / R Alt+Tab / ZR Windows");
 #endif
 }
 
@@ -329,6 +344,10 @@ void StreamView::HideInlineKeyboard(bool send_enter) {
     swkbdInlineDisappear(&inline_keyboard_);
     keyboard_visible_ = false;
     keyboard_text_.clear();
+    keyboard_escape_chord_was_down_ = false;
+    keyboard_tab_chord_was_down_ = false;
+    keyboard_alt_tab_chord_was_down_ = false;
+    keyboard_windows_chord_was_down_ = false;
     gamepad_state_initialized_ = false;
     suppress_b_until_release_ = true;
     keyboard_release_guard_ = true;
@@ -363,6 +382,10 @@ void StreamView::KeyboardEnterCallback(const char* text, SwkbdDecidedEnterArg*) 
     active_keyboard_view_->SendKeyboardCharacter('\n');
     active_keyboard_view_->keyboard_visible_ = false;
     active_keyboard_view_->keyboard_text_.clear();
+    active_keyboard_view_->keyboard_escape_chord_was_down_ = false;
+    active_keyboard_view_->keyboard_tab_chord_was_down_ = false;
+    active_keyboard_view_->keyboard_alt_tab_chord_was_down_ = false;
+    active_keyboard_view_->keyboard_windows_chord_was_down_ = false;
     active_keyboard_view_->gamepad_state_initialized_ = false;
     active_keyboard_view_->keyboard_release_guard_ = true;
     if (active_keyboard_view_->session_)
@@ -374,6 +397,10 @@ void StreamView::KeyboardCancelCallback() {
         return;
     active_keyboard_view_->keyboard_visible_ = false;
     active_keyboard_view_->keyboard_text_.clear();
+    active_keyboard_view_->keyboard_escape_chord_was_down_ = false;
+    active_keyboard_view_->keyboard_tab_chord_was_down_ = false;
+    active_keyboard_view_->keyboard_alt_tab_chord_was_down_ = false;
+    active_keyboard_view_->keyboard_windows_chord_was_down_ = false;
     active_keyboard_view_->gamepad_state_initialized_ = false;
     active_keyboard_view_->suppress_b_until_release_ = true;
     active_keyboard_view_->keyboard_release_guard_ = true;

--- a/app/src/stream_view_overlay.cpp
+++ b/app/src/stream_view_overlay.cpp
@@ -584,6 +584,7 @@ void StreamView::DrawStreamOverlay(
 
     draw_shortcut(right_y, "MINUS  +  PLUS", "Open or close this menu", true);
     draw_shortcut(right_y, "MINUS  +  Y", "Open the on-screen keyboard");
+    draw_shortcut(right_y, "MINUS + ZL/L/R/ZR", "Keyboard: Esc / Tab / Alt+Tab / Win");
     draw_shortcut(right_y, "B", "Close menu or keyboard");
     draw_shortcut(right_y, "ZL + ZR + MINUS", "Exit the stream");
     draw_shortcut(right_y, "HOLD PLUS", "Press the Xbox Guide button");

--- a/tests/keyboard_input_policy_test.cpp
+++ b/tests/keyboard_input_policy_test.cpp
@@ -5,7 +5,9 @@
 int main()
 {
     using opennow::input::KeyboardStroke;
+    using opennow::input::KeyboardShortcut;
     using opennow::input::MapAsciiKey;
+    using opennow::input::MapKeyboardShortcut;
 
     KeyboardStroke stroke;
     assert(MapAsciiKey('a', stroke));
@@ -24,5 +26,19 @@ int main()
     assert(stroke.keycode == 0x20 && stroke.scancode == 0x39 && stroke.modifiers == 0);
 
     assert(!MapAsciiKey('\t', stroke));
+
+    stroke = MapKeyboardShortcut(KeyboardShortcut::Escape);
+    assert(stroke.keycode == 0x1b && stroke.scancode == 0x01 && stroke.modifiers == 0);
+
+    stroke = MapKeyboardShortcut(KeyboardShortcut::Tab);
+    assert(stroke.keycode == 0x09 && stroke.scancode == 0x0f && stroke.modifiers == 0);
+
+    stroke = MapKeyboardShortcut(KeyboardShortcut::AltTab);
+    assert(stroke.keycode == 0x09 && stroke.scancode == 0x0f &&
+           stroke.modifiers == 0x0004);
+
+    stroke = MapKeyboardShortcut(KeyboardShortcut::Windows);
+    assert(stroke.keycode == 0x5b && stroke.scancode == 0x5b &&
+           stroke.modifiers == 0x0008);
     return 0;
 }


### PR DESCRIPTION
## Summary

- Add Minus-based controller chords for Escape, Tab, Alt+Tab, and Windows keys.
- Send mapped shortcuts as press/release keyboard events with edge-triggered handling.
- Document the new chords in the stream overlay and keyboard notification.
- Extend keyboard mapping policy tests for all shortcuts.

## Testing

- Added assertions covering Escape, Tab, Alt+Tab, and Windows key mappings in `keyboard_input_policy_test.cpp`.
- Not run: full Switch build or hardware gameplay validation.