### PR TITLE
Add multi-controller input assignment and delivery

### DIFF
--- a/app/src/StreamView.cpp
+++ b/app/src/StreamView.cpp
@@ -1,5 +1,4 @@
 #include "StreamView.hpp"
-#include "controller_layout.hpp"
 #include "input/TouchMapping.hpp"
 #include "stream/ffmpeg/AVFrameHolder.hpp"
 #include "stream_diagnostics.hpp"
@@ -12,28 +11,6 @@
 
 namespace
 {
-
-void ApplyRadialDeadzone(float& x, float& y)
-{
-    constexpr float deadzone = 0.12f;
-    const float magnitude = std::sqrt(x * x + y * y);
-    if (magnitude <= deadzone) {
-        x = 0.0f;
-        y = 0.0f;
-        return;
-    }
-
-    const float normalized = std::min(1.0f, (magnitude - deadzone) / (1.0f - deadzone));
-    const float scale = normalized / magnitude;
-    x *= scale;
-    y *= scale;
-}
-
-int16_t QuantizeAxis(float value)
-{
-    value = std::max(-1.0f, std::min(1.0f, value));
-    return static_cast<int16_t>(std::lround(value * 32767.0f));
-}
 
 bool IsFreeTier(std::string tier)
 {
@@ -74,6 +51,15 @@ StreamView::StreamView(
         nte_credentials_ = opennow::LoadNteCredentials();
         nte_status_until_ = stream_started_at_ + std::chrono::seconds(12);
     }
+#ifdef __SWITCH__
+    padInitialize(&switch_controller_sources_[0], HidNpadIdType_Handheld);
+    for (std::size_t source = 1; source < switch_controller_sources_.size(); ++source)
+    {
+        padInitialize(
+            &switch_controller_sources_[source],
+            static_cast<HidNpadIdType>(source - 1));
+    }
+#endif
     session_ = std::make_unique<WebRtcSession>(
         signaling_url,
         jwt_token,
@@ -178,6 +164,7 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
         brls::Application::getPlatform()->getInputManager()->updateUnifiedControllerState(&state);
 
         const auto input_now = std::chrono::steady_clock::now();
+        PollControllerStates(input_now);
         bool nte_owned_input = false;
         if (is_nte_session_ && !stream_overlay_visible_ &&
             stream_end_reason_ == opennow::StreamEndReason::None) {
@@ -281,23 +268,6 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
         if (!keyboard_owned_input) {
         
         const auto now = std::chrono::steady_clock::now();
-        const bool plus_down = state.buttons[brls::BUTTON_START];
-        if (plus_down && !plus_was_down_) {
-            plus_pressed_at_ = now;
-            plus_long_press_ = false;
-        }
-        if (plus_down && !plus_long_press_ &&
-            now - plus_pressed_at_ >= std::chrono::milliseconds(500)) {
-            plus_long_press_ = true;
-        }
-        if (!plus_down && plus_was_down_ && !plus_long_press_) {
-            // Keep Start pending until SCTP accepts it. Once delivered, keep
-            // it active for multiple reports and then send a clean release.
-            start_pulse_.Queue(now);
-            gamepad_state_initialized_ = false;
-            last_gamepad_report_ = {};
-        }
-        plus_was_down_ = plus_down;
 
         // Preserve the requested Minus -> View mapping. Exit the stream with
         // a deliberate ZL + ZR + Minus combination instead of stealing B.
@@ -311,69 +281,7 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
         }
         exit_combo_was_down_ = exit_combo;
 
-        const bool start_active = start_pulse_.IsActive(now);
-
-        uint16_t buttons = 0;
-        if (state.buttons[brls::BUTTON_UP]) buttons |= 0x0001;
-        if (state.buttons[brls::BUTTON_DOWN]) buttons |= 0x0002;
-        if (state.buttons[brls::BUTTON_LEFT]) buttons |= 0x0004;
-        if (state.buttons[brls::BUTTON_RIGHT]) buttons |= 0x0008;
-        if (start_active) buttons |= 0x0010;
-        if (state.buttons[brls::BUTTON_BACK]) buttons |= 0x0020;
-        if (plus_down && plus_long_press_) buttons |= 0x0400;
-        if (state.buttons[brls::BUTTON_LSB]) buttons |= 0x0040;
-        if (state.buttons[brls::BUTTON_RSB]) buttons |= 0x0080;
-        if (state.buttons[brls::BUTTON_LB]) buttons |= 0x0100;
-        if (state.buttons[brls::BUTTON_RB]) buttons |= 0x0200;
-        buttons |= opennow::MapFaceButtons(
-            controller_layout_,
-            state.buttons[brls::BUTTON_A],
-            state.buttons[brls::BUTTON_B] && !suppress_b_until_release_,
-            state.buttons[brls::BUTTON_X],
-            state.buttons[brls::BUTTON_Y]);
-        
-        float lx = state.axes[brls::LEFT_X];
-        float ly = state.axes[brls::LEFT_Y];
-        float rx = state.axes[brls::RIGHT_X];
-        float ry = state.axes[brls::RIGHT_Y];
-
-        ApplyRadialDeadzone(lx, ly);
-        ApplyRadialDeadzone(rx, ry);
-        const uint8_t left_trigger = state.buttons[brls::BUTTON_LT] ? 0xff : 0x00;
-        const uint8_t right_trigger = state.buttons[brls::BUTTON_RT] ? 0xff : 0x00;
-        const int16_t qlx = QuantizeAxis(lx);
-        const int16_t qly = QuantizeAxis(ly);
-        const int16_t qrx = QuantizeAxis(rx);
-        const int16_t qry = QuantizeAxis(ry);
-        const bool state_changed = !gamepad_state_initialized_ ||
-            buttons != last_gamepad_buttons_ ||
-            left_trigger != last_left_trigger_ || right_trigger != last_right_trigger_ ||
-            qlx != last_lx_ || qly != last_ly_ || qrx != last_rx_ || qry != last_ry_;
-        const bool keepalive_due = last_gamepad_report_.time_since_epoch().count() == 0 ||
-            now - last_gamepad_report_ >= std::chrono::milliseconds(100);
-
-        if (state_changed || keepalive_due) {
-            const bool delivered = session_->send_gamepad_input(
-                buttons, left_trigger, right_trigger, lx, ly, rx, ry);
-            if (delivered) {
-                gamepad_state_initialized_ = true;
-                last_gamepad_buttons_ = buttons;
-                last_left_trigger_ = left_trigger;
-                last_right_trigger_ = right_trigger;
-                last_lx_ = qlx;
-                last_ly_ = qly;
-                last_rx_ = qrx;
-                last_ry_ = qry;
-                last_gamepad_report_ = now;
-                if (start_active && start_pulse_.OnReportDelivered(now)) {
-                    gamepad_state_initialized_ = false;
-                }
-            } else {
-                // Retry on the next frame instead of treating a blocked or
-                // failed report as delivered after a long idle period.
-                gamepad_state_initialized_ = false;
-            }
-        }
+        SendControllerInputs(now);
 
         std::vector<brls::RawTouchState> touches;
         brls::Application::getPlatform()->getInputManager()->updateTouchStates(&touches);
@@ -475,6 +383,8 @@ void StreamView::draw(NVGcontext* vg, float x, float y, float width, float heigh
         DrawStreamOverlay(vg, x, y, width, height, notice_now);
     if (stream_end_reason_ == opennow::StreamEndReason::None)
         DrawNetworkWarning(vg, x, y, width, height, notice_now);
+    if (stream_end_reason_ == opennow::StreamEndReason::None)
+        DrawControllerNotice(vg, x, y, width, notice_now);
 
     brls::Box::draw(vg, x, y, width, height, style, ctx);
 }

--- a/app/src/StreamView.hpp
+++ b/app/src/StreamView.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <borealis.hpp>
+#include "controller_assignment_policy.hpp"
 #include "gfn_client.hpp"
 #include "controller_delivery_policy.hpp"
 #include "network_utils.hpp"
@@ -8,8 +9,10 @@
 #include "stream_overlay_policy.hpp"
 #include "webrtc_session.hpp"
 
+#include <array>
 #include <chrono>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <string>
 #include <vector>
@@ -68,6 +71,18 @@ private:
                         std::chrono::steady_clock::time_point now);
     void DrawStreamEndNotice(NVGcontext* vg, float x, float y, float width,
                              std::chrono::steady_clock::time_point now);
+    void PollControllerStates(std::chrono::steady_clock::time_point now);
+    void SendControllerInputs(std::chrono::steady_clock::time_point now);
+    void ResetControllerDeliveryState();
+    void SendNeutralControllerReports();
+    void QueueControllerConnectedNotice(
+        std::size_t controller, std::chrono::steady_clock::time_point now);
+    void UpdateControllerNotice(std::chrono::steady_clock::time_point now);
+    void DrawControllerNotice(NVGcontext* vg, float x, float y, float width,
+                              std::chrono::steady_clock::time_point now);
+#ifdef __SWITCH__
+    bool ReadSwitchControllerSource(std::size_t source, brls::ControllerState& state);
+#endif
     void OpenInlineKeyboard();
     void HideInlineKeyboard(bool send_enter);
     void UpdateInlineKeyboard();
@@ -110,6 +125,23 @@ private:
         SubmitLogin,
     };
 
+    struct ControllerDeliveryState {
+        bool initialized = false;
+        bool pending_disconnect = false;
+        bool plus_was_down = false;
+        bool plus_long_press = false;
+        uint16_t last_buttons = 0;
+        uint8_t last_left_trigger = 0;
+        uint8_t last_right_trigger = 0;
+        int16_t last_lx = 0;
+        int16_t last_ly = 0;
+        int16_t last_rx = 0;
+        int16_t last_ry = 0;
+        std::chrono::steady_clock::time_point plus_pressed_at {};
+        std::chrono::steady_clock::time_point last_report {};
+        opennow::input::StartDeliveryPulse start_pulse;
+    };
+
     std::unique_ptr<WebRtcSession> session_;
     opennow::GfnClient client_;
     opennow::AuthSession auth_;
@@ -136,8 +168,6 @@ private:
     std::string nte_status_;
     std::chrono::steady_clock::time_point nte_next_action_ {};
     std::chrono::steady_clock::time_point nte_status_until_ {};
-    bool plus_was_down_ = false;
-    bool plus_long_press_ = false;
     bool exit_requested_ = false;
     bool exit_combo_was_down_ = false;
     bool touch_was_down_ = false;
@@ -157,8 +187,20 @@ private:
 #ifdef __SWITCH__
     SwkbdInline inline_keyboard_ {};
 #endif
-    std::chrono::steady_clock::time_point plus_pressed_at_ {};
-    opennow::input::StartDeliveryPulse start_pulse_;
+    opennow::input::ControllerAssignments controller_assignments_;
+    std::array<brls::ControllerState, opennow::input::kRemoteControllerCount>
+        controller_states_ {};
+    std::array<bool, opennow::input::kRemoteControllerCount> controller_connected_ {};
+    std::array<ControllerDeliveryState, opennow::input::kRemoteControllerCount>
+        controller_delivery_ {};
+    bool controller_connections_initialized_ = false;
+    std::string controller_notice_text_;
+    std::deque<std::string> controller_notice_queue_;
+    std::chrono::steady_clock::time_point controller_notice_visible_until_ {};
+#ifdef __SWITCH__
+    std::array<PadState, opennow::input::kSwitchControllerSourceCount>
+        switch_controller_sources_ {};
+#endif
     std::chrono::steady_clock::time_point fps_window_started_ {};
     VideoPerformanceCounters previous_video_counters_ {};
     float incoming_fps_ = 0.0f;
@@ -167,15 +209,6 @@ private:
     float stream_bitrate_mbps_ = 0.0f;
     int network_rtt_ms_ = -1;
     StreamNetworkCounters network_counters_ {};
-    bool gamepad_state_initialized_ = false;
-    uint16_t last_gamepad_buttons_ = 0;
-    uint8_t last_left_trigger_ = 0;
-    uint8_t last_right_trigger_ = 0;
-    int16_t last_lx_ = 0;
-    int16_t last_ly_ = 0;
-    int16_t last_rx_ = 0;
-    int16_t last_ry_ = 0;
-    std::chrono::steady_clock::time_point last_gamepad_report_ {};
     bool free_tier_session_ = false;
     bool five_minute_warning_shown_ = false;
     bool one_minute_warning_shown_ = false;

--- a/app/src/controller_assignment_policy.hpp
+++ b/app/src/controller_assignment_policy.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace opennow::input
+{
+
+constexpr std::size_t kRemoteControllerCount = 4;
+constexpr std::size_t kSwitchControllerSourceCount = 5;
+constexpr std::int8_t kUnassignedController = -1;
+
+class ControllerAssignments
+{
+  public:
+    ControllerAssignments()
+    {
+        source_to_controller_.fill(kUnassignedController);
+        controller_to_source_.fill(kUnassignedController);
+    }
+
+    std::int8_t Assign(std::size_t source)
+    {
+        if (source >= source_to_controller_.size())
+            return kUnassignedController;
+        if (source_to_controller_[source] != kUnassignedController)
+            return source_to_controller_[source];
+
+        // Handheld and Npad No1 both naturally prefer player one. If both are
+        // active, whichever was observed first keeps it and the other takes
+        // the next free position. Assignments remain reserved on disconnect.
+        const std::size_t preferred = source == 0 ? 0 : source - 1;
+        if (preferred < controller_to_source_.size() &&
+            controller_to_source_[preferred] == kUnassignedController)
+        {
+            return Bind(source, preferred);
+        }
+
+        for (std::size_t controller = 0;
+             controller < controller_to_source_.size(); ++controller)
+        {
+            if (controller_to_source_[controller] == kUnassignedController)
+                return Bind(source, controller);
+        }
+        return kUnassignedController;
+    }
+
+    std::int8_t ControllerForSource(std::size_t source) const
+    {
+        return source < source_to_controller_.size()
+            ? source_to_controller_[source]
+            : kUnassignedController;
+    }
+
+  private:
+    std::int8_t Bind(std::size_t source, std::size_t controller)
+    {
+        source_to_controller_[source] = static_cast<std::int8_t>(controller);
+        controller_to_source_[controller] = static_cast<std::int8_t>(source);
+        return static_cast<std::int8_t>(controller);
+    }
+
+    std::array<std::int8_t, kSwitchControllerSourceCount> source_to_controller_;
+    std::array<std::int8_t, kRemoteControllerCount> controller_to_source_;
+};
+
+inline std::uint16_t ControllerBitmap(
+    const std::array<bool, kRemoteControllerCount>& connected)
+{
+    std::uint16_t bitmap = 0;
+    for (std::size_t controller = 0; controller < connected.size(); ++controller)
+    {
+        if (!connected[controller])
+            continue;
+        bitmap |= static_cast<std::uint16_t>(1u << controller);
+        bitmap |= static_cast<std::uint16_t>(1u << (controller + 8));
+    }
+    return bitmap;
+}
+
+} // namespace opennow::input

--- a/app/src/stream_view_controller.cpp
+++ b/app/src/stream_view_controller.cpp
@@ -1,0 +1,365 @@
+#include "StreamView.hpp"
+#include "controller_layout.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace
+{
+
+void ApplyRadialDeadzone(float& x, float& y)
+{
+    constexpr float deadzone = 0.12f;
+    const float magnitude = std::sqrt(x * x + y * y);
+    if (magnitude <= deadzone)
+    {
+        x = 0.0f;
+        y = 0.0f;
+        return;
+    }
+
+    const float normalized = std::min(1.0f, (magnitude - deadzone) / (1.0f - deadzone));
+    const float scale = normalized / magnitude;
+    x *= scale;
+    y *= scale;
+}
+
+int16_t QuantizeAxis(float value)
+{
+    value = std::clamp(value, -1.0f, 1.0f);
+    return static_cast<int16_t>(std::lround(value * 32767.0f));
+}
+
+} // namespace
+
+void StreamView::PollControllerStates(std::chrono::steady_clock::time_point now)
+{
+    std::array<bool, opennow::input::kRemoteControllerCount> connected {};
+    std::array<brls::ControllerState, opennow::input::kRemoteControllerCount> states {};
+
+#ifdef __SWITCH__
+    for (std::size_t source = 0; source < switch_controller_sources_.size(); ++source)
+    {
+        brls::ControllerState state {};
+        if (!ReadSwitchControllerSource(source, state))
+            continue;
+
+        const std::int8_t controller = controller_assignments_.Assign(source);
+        if (controller < 0)
+            continue;
+        connected[static_cast<std::size_t>(controller)] = true;
+        states[static_cast<std::size_t>(controller)] = state;
+    }
+#else
+    auto* input = brls::Application::getPlatform()->getInputManager();
+    const std::size_t count = static_cast<std::size_t>(
+        std::max<short>(0, input->getControllersConnectedCount()));
+    for (std::size_t index = 0;
+         index < std::min(count, opennow::input::kRemoteControllerCount); ++index)
+    {
+        const std::int8_t controller = controller_assignments_.Assign(index + 1);
+        if (controller < 0)
+            continue;
+        brls::ControllerState state {};
+        input->updateControllerState(&state, static_cast<int>(index));
+        connected[static_cast<std::size_t>(controller)] = true;
+        states[static_cast<std::size_t>(controller)] = state;
+    }
+#endif
+
+    if (controller_connections_initialized_)
+    {
+        for (std::size_t controller = 0; controller < connected.size(); ++controller)
+        {
+            auto& delivery = controller_delivery_[controller];
+            if (!controller_connected_[controller] && connected[controller])
+            {
+                delivery.initialized = false;
+                delivery.pending_disconnect = false;
+                QueueControllerConnectedNotice(controller, now);
+                if (session_)
+                    session_->record_ui_event(
+                        "controller connected player=" + std::to_string(controller + 1));
+            }
+            else if (controller_connected_[controller] && !connected[controller])
+            {
+                delivery.initialized = false;
+                delivery.pending_disconnect = true;
+                delivery.plus_was_down = false;
+                delivery.plus_long_press = false;
+                delivery.start_pulse = {};
+                if (session_)
+                    session_->record_ui_event(
+                        "controller disconnected player=" + std::to_string(controller + 1));
+            }
+        }
+    }
+    else
+    {
+        controller_connections_initialized_ = true;
+    }
+
+    controller_connected_ = connected;
+    controller_states_ = states;
+    UpdateControllerNotice(now);
+}
+
+#ifdef __SWITCH__
+bool StreamView::ReadSwitchControllerSource(
+    std::size_t source, brls::ControllerState& state)
+{
+    if (source >= switch_controller_sources_.size())
+        return false;
+
+    PadState& pad = switch_controller_sources_[source];
+    padUpdate(&pad);
+    const bool active = source == 0
+        ? padIsHandheld(&pad)
+        : padIsNpadActive(&pad, static_cast<HidNpadIdType>(source - 1));
+    if (!active)
+        return false;
+
+    state = {};
+    const uint64_t buttons = padGetButtons(&pad);
+    const bool full = (padGetStyleSet(&pad) & HidNpadStyleSet_NpadFullCtrl) != 0;
+    if (full)
+    {
+        state.buttons[brls::BUTTON_LT] = buttons & HidNpadButton_ZL;
+        state.buttons[brls::BUTTON_LB] = buttons & HidNpadButton_L;
+        state.buttons[brls::BUTTON_LSB] = buttons & HidNpadButton_StickL;
+        state.buttons[brls::BUTTON_UP] = buttons & HidNpadButton_Up;
+        state.buttons[brls::BUTTON_RIGHT] = buttons & HidNpadButton_Right;
+        state.buttons[brls::BUTTON_DOWN] = buttons & HidNpadButton_Down;
+        state.buttons[brls::BUTTON_LEFT] = buttons & HidNpadButton_Left;
+        state.buttons[brls::BUTTON_BACK] = buttons & HidNpadButton_Minus;
+        state.buttons[brls::BUTTON_START] = buttons & HidNpadButton_Plus;
+        state.buttons[brls::BUTTON_RSB] = buttons & HidNpadButton_StickR;
+        state.buttons[brls::BUTTON_Y] = buttons & HidNpadButton_Y;
+        state.buttons[brls::BUTTON_B] = buttons & HidNpadButton_B;
+        state.buttons[brls::BUTTON_A] = buttons & HidNpadButton_A;
+        state.buttons[brls::BUTTON_X] = buttons & HidNpadButton_X;
+        state.buttons[brls::BUTTON_RB] = buttons & HidNpadButton_R;
+        state.buttons[brls::BUTTON_RT] = buttons & HidNpadButton_ZR;
+
+        const HidAnalogStickState left = padGetStickPos(&pad, 0);
+        const HidAnalogStickState right = padGetStickPos(&pad, 1);
+        state.axes[brls::LEFT_X] = static_cast<float>(left.x) / 32767.0f;
+        state.axes[brls::LEFT_Y] = -static_cast<float>(left.y) / 32767.0f;
+        state.axes[brls::RIGHT_X] = static_cast<float>(right.x) / 32767.0f;
+        state.axes[brls::RIGHT_Y] = -static_cast<float>(right.y) / 32767.0f;
+    }
+    else
+    {
+        state.buttons[brls::BUTTON_LB] = buttons & HidNpadButton_AnySL;
+        state.buttons[brls::BUTTON_LSB] =
+            buttons & (HidNpadButton_StickL | HidNpadButton_StickR);
+        state.buttons[brls::BUTTON_START] =
+            buttons & (HidNpadButton_Plus | HidNpadButton_Minus);
+        state.buttons[brls::BUTTON_Y] =
+            buttons & (HidNpadButton_B | HidNpadButton_Up);
+        state.buttons[brls::BUTTON_B] =
+            buttons & (HidNpadButton_A | HidNpadButton_Left);
+        state.buttons[brls::BUTTON_A] =
+            buttons & (HidNpadButton_X | HidNpadButton_Down);
+        state.buttons[brls::BUTTON_X] =
+            buttons & (HidNpadButton_Y | HidNpadButton_Right);
+        state.buttons[brls::BUTTON_RB] = buttons & HidNpadButton_AnySR;
+
+        const HidAnalogStickState left = padGetStickPos(&pad, 0);
+        const HidAnalogStickState right = padGetStickPos(&pad, 1);
+        const float axis_x =
+            -static_cast<float>(left.y) / 32767.0f +
+            static_cast<float>(right.y) / 32767.0f;
+        const float axis_y =
+            -static_cast<float>(left.x) / 32767.0f +
+            static_cast<float>(right.x) / 32767.0f;
+        if (brls::Application::isSwapHalfJoyconStickToDpad())
+        {
+            state.buttons[brls::BUTTON_UP] = axis_y < -0.3f;
+            state.buttons[brls::BUTTON_DOWN] = axis_y > 0.3f;
+            state.buttons[brls::BUTTON_RIGHT] = axis_x > 0.3f;
+            state.buttons[brls::BUTTON_LEFT] = axis_x < -0.3f;
+        }
+        else
+        {
+            state.axes[brls::LEFT_X] = axis_x;
+            state.axes[brls::LEFT_Y] = axis_y;
+        }
+    }
+    return true;
+}
+#endif
+
+void StreamView::SendControllerInputs(std::chrono::steady_clock::time_point now)
+{
+    if (!session_)
+        return;
+
+    const uint16_t bitmap = opennow::input::ControllerBitmap(controller_connected_);
+    for (std::size_t controller = 0; controller < controller_delivery_.size(); ++controller)
+    {
+        auto& delivery = controller_delivery_[controller];
+        if (!delivery.pending_disconnect)
+            continue;
+        if (session_->send_gamepad_input(
+                static_cast<uint8_t>(controller), bitmap,
+                0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f))
+        {
+            delivery.pending_disconnect = false;
+        }
+    }
+
+    for (std::size_t controller = 0; controller < controller_states_.size(); ++controller)
+    {
+        if (!controller_connected_[controller])
+            continue;
+
+        const brls::ControllerState& state = controller_states_[controller];
+        auto& delivery = controller_delivery_[controller];
+        const bool plus_down = state.buttons[brls::BUTTON_START];
+        if (plus_down && !delivery.plus_was_down)
+        {
+            delivery.plus_pressed_at = now;
+            delivery.plus_long_press = false;
+        }
+        if (plus_down && !delivery.plus_long_press &&
+            now - delivery.plus_pressed_at >= std::chrono::milliseconds(500))
+        {
+            delivery.plus_long_press = true;
+        }
+        if (!plus_down && delivery.plus_was_down && !delivery.plus_long_press)
+        {
+            delivery.start_pulse.Queue(now);
+            delivery.initialized = false;
+            delivery.last_report = {};
+        }
+        delivery.plus_was_down = plus_down;
+
+        const bool start_active = delivery.start_pulse.IsActive(now);
+        uint16_t buttons = 0;
+        if (state.buttons[brls::BUTTON_UP]) buttons |= 0x0001;
+        if (state.buttons[brls::BUTTON_DOWN]) buttons |= 0x0002;
+        if (state.buttons[brls::BUTTON_LEFT]) buttons |= 0x0004;
+        if (state.buttons[brls::BUTTON_RIGHT]) buttons |= 0x0008;
+        if (start_active) buttons |= 0x0010;
+        if (state.buttons[brls::BUTTON_BACK]) buttons |= 0x0020;
+        if (delivery.plus_long_press && plus_down) buttons |= 0x0400;
+        if (state.buttons[brls::BUTTON_LSB]) buttons |= 0x0040;
+        if (state.buttons[brls::BUTTON_RSB]) buttons |= 0x0080;
+        if (state.buttons[brls::BUTTON_LB]) buttons |= 0x0100;
+        if (state.buttons[brls::BUTTON_RB]) buttons |= 0x0200;
+        buttons |= opennow::MapFaceButtons(
+            controller_layout_,
+            state.buttons[brls::BUTTON_A],
+            state.buttons[brls::BUTTON_B] && !suppress_b_until_release_,
+            state.buttons[brls::BUTTON_X],
+            state.buttons[brls::BUTTON_Y]);
+
+        float lx = state.axes[brls::LEFT_X];
+        float ly = state.axes[brls::LEFT_Y];
+        float rx = state.axes[brls::RIGHT_X];
+        float ry = state.axes[brls::RIGHT_Y];
+        ApplyRadialDeadzone(lx, ly);
+        ApplyRadialDeadzone(rx, ry);
+
+        const uint8_t left_trigger = state.buttons[brls::BUTTON_LT] ? 0xff : 0x00;
+        const uint8_t right_trigger = state.buttons[brls::BUTTON_RT] ? 0xff : 0x00;
+        const int16_t qlx = QuantizeAxis(lx);
+        const int16_t qly = QuantizeAxis(ly);
+        const int16_t qrx = QuantizeAxis(rx);
+        const int16_t qry = QuantizeAxis(ry);
+        const bool state_changed = !delivery.initialized ||
+            buttons != delivery.last_buttons ||
+            left_trigger != delivery.last_left_trigger ||
+            right_trigger != delivery.last_right_trigger ||
+            qlx != delivery.last_lx || qly != delivery.last_ly ||
+            qrx != delivery.last_rx || qry != delivery.last_ry;
+        const bool keepalive_due = delivery.last_report.time_since_epoch().count() == 0 ||
+            now - delivery.last_report >= std::chrono::milliseconds(100);
+        if (!state_changed && !keepalive_due)
+            continue;
+
+        const bool delivered = session_->send_gamepad_input(
+            static_cast<uint8_t>(controller), bitmap, buttons,
+            left_trigger, right_trigger, lx, ly, rx, ry);
+        if (!delivered)
+        {
+            delivery.initialized = false;
+            continue;
+        }
+
+        delivery.initialized = true;
+        delivery.last_buttons = buttons;
+        delivery.last_left_trigger = left_trigger;
+        delivery.last_right_trigger = right_trigger;
+        delivery.last_lx = qlx;
+        delivery.last_ly = qly;
+        delivery.last_rx = qrx;
+        delivery.last_ry = qry;
+        delivery.last_report = now;
+        if (start_active && delivery.start_pulse.OnReportDelivered(now))
+            delivery.initialized = false;
+    }
+}
+
+void StreamView::ResetControllerDeliveryState()
+{
+    for (auto& delivery : controller_delivery_)
+    {
+        const bool pending_disconnect = delivery.pending_disconnect;
+        delivery = {};
+        delivery.pending_disconnect = pending_disconnect;
+    }
+}
+
+void StreamView::SendNeutralControllerReports()
+{
+    if (!session_)
+        return;
+
+    const uint16_t bitmap = opennow::input::ControllerBitmap(controller_connected_);
+    for (std::size_t controller = 0; controller < controller_delivery_.size(); ++controller)
+    {
+        auto& delivery = controller_delivery_[controller];
+        if (!controller_connected_[controller] && !delivery.pending_disconnect)
+            continue;
+        const bool delivered = session_->send_gamepad_input(
+            static_cast<uint8_t>(controller), bitmap,
+            0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f);
+        if (delivered && delivery.pending_disconnect)
+            delivery.pending_disconnect = false;
+        delivery.initialized = false;
+    }
+}
+
+void StreamView::QueueControllerConnectedNotice(
+    std::size_t controller, std::chrono::steady_clock::time_point now)
+{
+    const std::string text = "Controller " + std::to_string(controller + 1) + " connected";
+    UpdateControllerNotice(now);
+    if (controller_notice_text_.empty())
+    {
+        controller_notice_text_ = text;
+        controller_notice_visible_until_ = now + std::chrono::seconds(3);
+    }
+    else
+    {
+        // Controller flapping must not create an unbounded UI queue on the
+        // streaming path. One queued notice per supported player is enough.
+        if (controller_notice_queue_.size() < opennow::input::kRemoteControllerCount)
+            controller_notice_queue_.push_back(text);
+    }
+}
+
+void StreamView::UpdateControllerNotice(std::chrono::steady_clock::time_point now)
+{
+    if (!controller_notice_text_.empty() && now >= controller_notice_visible_until_)
+        controller_notice_text_.clear();
+    if (controller_notice_text_.empty() && !controller_notice_queue_.empty())
+    {
+        controller_notice_text_ = std::move(controller_notice_queue_.front());
+        controller_notice_queue_.pop_front();
+        controller_notice_visible_until_ = now + std::chrono::seconds(3);
+    }
+}

--- a/app/src/stream_view_input.cpp
+++ b/app/src/stream_view_input.cpp
@@ -310,12 +310,12 @@ void StreamView::OpenInlineKeyboard() {
     keyboard_visible_ = true;
     keyboard_b_was_down_ = false;
     keyboard_plus_was_down_ = false;
-    gamepad_state_initialized_ = false;
+    ResetControllerDeliveryState();
     if (touch_was_down_) {
         session_->send_mouse_left_button(false);
         touch_was_down_ = false;
     }
-    session_->send_gamepad_input(0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f);
+    SendNeutralControllerReports();
     session_->record_ui_event("keyboard opened by Minus+Y");
 #endif
 }
@@ -329,7 +329,7 @@ void StreamView::HideInlineKeyboard(bool send_enter) {
     swkbdInlineDisappear(&inline_keyboard_);
     keyboard_visible_ = false;
     keyboard_text_.clear();
-    gamepad_state_initialized_ = false;
+    ResetControllerDeliveryState();
     suppress_b_until_release_ = true;
     keyboard_release_guard_ = true;
     if (session_)
@@ -363,7 +363,7 @@ void StreamView::KeyboardEnterCallback(const char* text, SwkbdDecidedEnterArg*) 
     active_keyboard_view_->SendKeyboardCharacter('\n');
     active_keyboard_view_->keyboard_visible_ = false;
     active_keyboard_view_->keyboard_text_.clear();
-    active_keyboard_view_->gamepad_state_initialized_ = false;
+    active_keyboard_view_->ResetControllerDeliveryState();
     active_keyboard_view_->keyboard_release_guard_ = true;
     if (active_keyboard_view_->session_)
         active_keyboard_view_->session_->record_ui_event("keyboard submitted");
@@ -374,7 +374,7 @@ void StreamView::KeyboardCancelCallback() {
         return;
     active_keyboard_view_->keyboard_visible_ = false;
     active_keyboard_view_->keyboard_text_.clear();
-    active_keyboard_view_->gamepad_state_initialized_ = false;
+    active_keyboard_view_->ResetControllerDeliveryState();
     active_keyboard_view_->suppress_b_until_release_ = true;
     active_keyboard_view_->keyboard_release_guard_ = true;
     if (active_keyboard_view_->session_)

--- a/app/src/stream_view_overlay.cpp
+++ b/app/src/stream_view_overlay.cpp
@@ -233,10 +233,7 @@ void StreamView::SetStreamOverlayVisible(bool visible)
 
     stream_overlay_visible_ = visible;
     stream_overlay_b_was_down_ = false;
-    gamepad_state_initialized_ = false;
-    plus_was_down_ = false;
-    plus_long_press_ = false;
-    start_pulse_ = {};
+    ResetControllerDeliveryState();
 
     if (touch_was_down_ && session_)
     {
@@ -245,7 +242,7 @@ void StreamView::SetStreamOverlayVisible(bool visible)
     }
     if (session_)
     {
-        session_->send_gamepad_input(0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f);
+        SendNeutralControllerReports();
         session_->record_ui_event(
             visible ? "stream overlay opened by Minus+Plus"
                     : "stream overlay closed");
@@ -253,6 +250,38 @@ void StreamView::SetStreamOverlayVisible(bool visible)
 
     if (!visible)
         keyboard_release_guard_ = true;
+}
+
+void StreamView::DrawControllerNotice(
+    NVGcontext* vg, float x, float y, float width,
+    std::chrono::steady_clock::time_point now)
+{
+    UpdateControllerNotice(now);
+    if (controller_notice_text_.empty())
+        return;
+
+    const float box_width = std::min(360.0f, width - 36.0f);
+    const float box_height = 54.0f;
+    const float box_x = x + (width - box_width) * 0.5f;
+    const float box_y = y + 18.0f;
+
+    nvgBeginPath(vg);
+    nvgRoundedRect(vg, box_x, box_y, box_width, box_height, 13.0f);
+    nvgFillColor(vg, nvgRGBA(7, 11, 14, 232));
+    nvgFill(vg);
+
+    nvgBeginPath(vg);
+    nvgRoundedRect(vg, box_x, box_y, 6.0f, box_height, 3.0f);
+    nvgFillColor(vg, nvgRGB(55, 220, 125));
+    nvgFill(vg);
+
+    nvgFontSize(vg, 21.0f);
+    nvgFontFaceId(vg, brls::Application::getFont(brls::FONT_REGULAR));
+    nvgFillColor(vg, nvgRGB(248, 252, 249));
+    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+    nvgText(
+        vg, box_x + box_width * 0.5f, box_y + box_height * 0.5f,
+        controller_notice_text_.c_str(), nullptr);
 }
 
 void StreamView::RefreshNetworkInfo(std::chrono::steady_clock::time_point now)

--- a/app/src/webrtc/input.cpp
+++ b/app/src/webrtc/input.cpp
@@ -118,7 +118,8 @@ int16_t AxisToI16(float value)
     return static_cast<int16_t>(value * 32767.0f);
 }
 
-std::vector<uint8_t> BuildGamepadPayload(uint64_t timestamp_us, uint16_t buttons,
+std::vector<uint8_t> BuildGamepadPayload(uint64_t timestamp_us, uint8_t controller_id,
+                                         uint16_t controller_bitmap, uint16_t buttons,
                                          uint8_t left_trigger, uint8_t right_trigger,
                                          int16_t lx, int16_t ly, int16_t rx, int16_t ry)
 {
@@ -126,8 +127,8 @@ std::vector<uint8_t> BuildGamepadPayload(uint64_t timestamp_us, uint16_t buttons
     payload.reserve(38);
     PutU32Le(payload, 12);
     PutU16Le(payload, 26);
-    PutU16Le(payload, 0);
-    PutU16Le(payload, 0x0101);
+    PutU16Le(payload, controller_id);
+    PutU16Le(payload, controller_bitmap);
     PutU16Le(payload, 20);
     PutU16Le(payload, buttons);
     PutU16Le(payload, static_cast<uint16_t>(left_trigger | (right_trigger << 8)));
@@ -189,8 +190,10 @@ namespace opennow::webrtc::internal
 bool InputEncodingSelfTest()
 {
     constexpr uint64_t timestamp = 0x0102030405060708ULL;
-    const auto raw = BuildGamepadPayload(timestamp, 0x1234, 0x56, 0x78, 1, -2, 3, -4);
-    if (raw.size() != 38 || raw[0] != 12 || raw[8] != 0x01 || raw[9] != 0x01 ||
+    const auto raw = BuildGamepadPayload(
+        timestamp, 2, 0x0f0f, 0x1234, 0x56, 0x78, 1, -2, 3, -4);
+    if (raw.size() != 38 || raw[0] != 12 ||
+        raw[6] != 2 || raw[7] != 0 || raw[8] != 0x0f || raw[9] != 0x0f ||
         raw[24] != 0 || raw[25] != 0 || raw[26] != 0x55 || raw[27] != 0 ||
         raw[28] != 0 || raw[29] != 0 || raw[30] != 0x08 || raw[37] != 0x01) {
         return false;
@@ -202,9 +205,9 @@ bool InputEncodingSelfTest()
         return false;
     }
 
-    const auto partial = WrapPartiallyReliableGamepad(3, timestamp, 0, 1, raw);
+    const auto partial = WrapPartiallyReliableGamepad(3, timestamp, 2, 1, raw);
     if (partial.size() != 54 || partial[0] != 0x23 || partial[9] != 0x26 ||
-        partial[10] != 0 || partial[11] != 0 || partial[12] != 1 ||
+        partial[10] != 2 || partial[11] != 0 || partial[12] != 1 ||
         partial[13] != 0x21 || partial[14] != 0 || partial[15] != 38 || partial[16] != 12) {
         return false;
     }
@@ -227,6 +230,8 @@ bool InputEncodingSelfTest()
 } // namespace opennow::webrtc::internal
 
 bool WebRtcSession::send_gamepad_input(
+    uint8_t controller_id,
+    uint16_t controller_bitmap,
     uint16_t buttons,
     uint8_t left_trigger,
     uint8_t right_trigger,
@@ -234,6 +239,9 @@ bool WebRtcSession::send_gamepad_input(
     float ly,
     float rx,
     float ry) {
+    if (controller_id >= gamepad_sequences_.size())
+        return false;
+
     std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
     gamepad_input_attempt_count_++;
     const PeerConnectionState peer_state = pc_ ? peer_connection_get_state(pc_) : PEER_CONNECTION_CLOSED;
@@ -253,12 +261,15 @@ bool WebRtcSession::send_gamepad_input(
 
     const uint64_t timestamp_us = NowUs();
     const std::vector<uint8_t> payload = BuildGamepadPayload(
-        timestamp_us, buttons, left_trigger, right_trigger,
+        timestamp_us, controller_id, controller_bitmap, buttons,
+        left_trigger, right_trigger,
         AxisToI16(lx), AxisToI16(-ly), AxisToI16(rx), AxisToI16(-ry));
 
     const bool use_partial = partial_input_channel_requested_ && input_protocol_version_ >= 3;
     std::vector<uint8_t> wire_payload = use_partial
-        ? WrapPartiallyReliableGamepad(input_protocol_version_, timestamp_us, 0, gamepad_sequence_++, payload)
+        ? WrapPartiallyReliableGamepad(
+            input_protocol_version_, timestamp_us, controller_id,
+            gamepad_sequences_[controller_id]++, payload)
         : WrapReliableGamepad(input_protocol_version_, timestamp_us, payload);
     const uint16_t sid = use_partial ? 2 : 0;
     const int sent = send_datachannel_binary(sid, "gamepad", wire_payload.data(), wire_payload.size());
@@ -272,6 +283,8 @@ bool WebRtcSession::send_gamepad_input(
                        " report=" + std::to_string(gamepad_tx_count_) +
                        " sid=" + std::to_string(sid) +
                        " protocol=" + std::to_string(input_protocol_version_) +
+                       " controller=" + std::to_string(controller_id) +
+                       " bitmap=" + std::to_string(controller_bitmap) +
                        " buttons=" + std::to_string(buttons) +
                        " lt=" + std::to_string(left_trigger) +
                        " rt=" + std::to_string(right_trigger) +

--- a/app/src/webrtc_session.hpp
+++ b/app/src/webrtc_session.hpp
@@ -72,7 +72,8 @@ public:
     void request_stop();
     void stop();
     void poll();
-    bool send_gamepad_input(uint16_t buttons, uint8_t left_trigger, uint8_t right_trigger,
+    bool send_gamepad_input(uint8_t controller_id, uint16_t controller_bitmap,
+                            uint16_t buttons, uint8_t left_trigger, uint8_t right_trigger,
                             float lx, float ly, float rx, float ry);
     void send_mouse_move(int16_t dx, int16_t dy);
     void send_mouse_left_button(bool pressed);
@@ -210,7 +211,7 @@ private:
     int gamepad_send_failure_count_ = 0;
     int consecutive_input_send_failures_ = 0;
     int mouse_tx_count_ = 0;
-    uint16_t gamepad_sequence_ = 1;
+    std::array<uint16_t, 4> gamepad_sequences_ {1, 1, 1, 1};
     bool first_video_packet_logged_ = false;
     bool first_decoded_frame_logged_ = false;
     int last_logged_packet_count_ = 0;

--- a/tests/controller_assignment_policy_test.cpp
+++ b/tests/controller_assignment_policy_test.cpp
@@ -1,0 +1,34 @@
+#include "controller_assignment_policy.hpp"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+
+int main()
+{
+    using opennow::input::ControllerAssignments;
+    using opennow::input::ControllerBitmap;
+
+    ControllerAssignments docked;
+    assert(docked.Assign(1) == 0);
+    assert(docked.Assign(2) == 1);
+    assert(docked.Assign(3) == 2);
+    assert(docked.Assign(4) == 3);
+    assert(docked.Assign(1) == 0);
+
+    ControllerAssignments handheld;
+    assert(handheld.Assign(0) == 0);
+    assert(handheld.Assign(1) == 1);
+    assert(handheld.Assign(2) == 2);
+    assert(handheld.Assign(3) == 3);
+    assert(handheld.Assign(4) == -1);
+
+    // A reconnect uses the reserved player number instead of compacting the
+    // remaining controllers into a different position.
+    assert(handheld.ControllerForSource(2) == 2);
+    assert(handheld.Assign(2) == 2);
+
+    const std::array<bool, 4> connected = {true, false, true, true};
+    assert(ControllerBitmap(connected) == static_cast<std::uint16_t>(0x0d0d));
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add support for assigning up to four controllers to remote players.
- Encode controller IDs, connection bitmaps, and per-controller input sequences in WebRTC gamepad reports.
- Handle controller connect/disconnect notifications and neutral reports during UI transitions.
- Add controller assignment policy coverage.

## Testing

- Not run (no test execution results provided).
- Added `controller_assignment_policy_test.cpp` for assignment and controller bitmap behavior.